### PR TITLE
feat: Replace navbar user elements with username dropdown menu

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 ]
 
 [project.urls]
-Documentation = "https://myk-org.github.io/docsfy/"
+Documentation = "https://myk-org.github.io/docsfy-docs/"
 Repository = "https://github.com/myk-org/docsfy"
 
 [project.scripts]

--- a/src/docsfy/static/style.css
+++ b/src/docsfy/static/style.css
@@ -365,22 +365,20 @@ a:hover {
 
 .theme-toggle {
     background: none;
-    border: 1px solid var(--border-primary);
+    border: none;
     color: var(--text-secondary);
     cursor: pointer;
-    padding: 7px;
-    border-radius: 8px;
+    padding: 6px;
+    border-radius: 6px;
     display: flex;
     align-items: center;
     justify-content: center;
-    transition: color var(--transition-fast), background-color var(--transition-fast),
-                border-color var(--transition-fast);
+    transition: color var(--transition-fast), background-color var(--transition-fast);
 }
 
 .theme-toggle:hover {
     color: var(--text-primary);
     background: var(--bg-tertiary);
-    border-color: var(--border-primary);
 }
 
 /* Show sun in dark mode, moon in light mode */

--- a/src/docsfy/templates/_user_menu.css
+++ b/src/docsfy/templates/_user_menu.css
@@ -1,0 +1,46 @@
+/* ---- User Menu Dropdown ---- */
+.user-menu { position: relative; }
+.user-menu-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 10px;
+    font-size: 0.85rem;
+    font-weight: 500;
+    font-family: inherit;
+    color: var(--text-secondary);
+    background: none;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    transition: color var(--transition-fast), background-color var(--transition-fast);
+    line-height: 1;
+}
+.user-menu-toggle:hover,
+.user-menu-toggle[aria-expanded="true"] {
+    color: var(--text-primary);
+    background: var(--bg-tertiary);
+}
+.user-menu-chevron { color: currentColor; transition: transform var(--transition-fast); }
+.user-menu-toggle[aria-expanded="true"] .user-menu-chevron { transform: rotate(180deg); }
+.user-menu-dropdown {
+    display: none; position: absolute; top: calc(100% + 6px); right: 0;
+    min-width: 200px; background: var(--bg-card);
+    border: 1px solid var(--border-primary); border-radius: 8px;
+    box-shadow: var(--shadow-md); padding: 4px 0; z-index: 150;
+}
+.user-menu-dropdown.open { display: block; }
+.user-menu-item {
+    display: flex; align-items: center; gap: 10px; width: 100%;
+    padding: 10px 14px; font-size: 0.8125rem; font-weight: 500; font-family: inherit;
+    color: var(--text-primary); background: none; border: none;
+    text-decoration: none; cursor: pointer;
+    transition: background var(--transition-fast); text-align: left;
+}
+.user-menu-item:hover { background: var(--bg-tertiary); }
+.user-menu-item svg { color: var(--text-tertiary); flex-shrink: 0; }
+.user-menu-item:hover svg { color: var(--text-secondary); }
+.user-menu-item-danger { color: var(--status-error); }
+.user-menu-item-danger svg { color: var(--status-error); }
+.user-menu-item-danger:hover { background: var(--status-error-bg); }
+.user-menu-divider { height: 1px; background: var(--border-primary); margin: 4px 0; }

--- a/src/docsfy/templates/_user_menu.js
+++ b/src/docsfy/templates/_user_menu.js
@@ -1,0 +1,30 @@
+<script>
+function closeUserMenu() {
+    var dropdown = document.getElementById('user-menu-dropdown');
+    var toggle = document.getElementById('user-menu-toggle');
+    if (dropdown) dropdown.classList.remove('open');
+    if (toggle) toggle.setAttribute('aria-expanded', 'false');
+}
+(function() {
+    var toggle = document.getElementById('user-menu-toggle');
+    var dropdown = document.getElementById('user-menu-dropdown');
+    if (!toggle || !dropdown) return;
+    toggle.addEventListener('click', function(e) {
+        e.stopPropagation();
+        var isOpen = dropdown.classList.contains('open');
+        if (isOpen) { closeUserMenu(); } else {
+            dropdown.classList.add('open');
+            toggle.setAttribute('aria-expanded', 'true');
+        }
+    });
+    document.addEventListener('click', function(e) {
+        if (!e.target.closest('#user-menu')) closeUserMenu();
+    });
+    document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape' && dropdown.classList.contains('open')) {
+            closeUserMenu();
+            toggle.focus();
+        }
+    });
+})();
+</script>

--- a/src/docsfy/templates/admin.html
+++ b/src/docsfy/templates/admin.html
@@ -99,42 +99,7 @@
     }
     .header-title { font-size: 0.875rem; color: var(--text-secondary); }
     .header-right { display: flex; align-items: center; gap: 0.75rem; }
-    /* ---- User Menu Dropdown ---- */
-    .user-menu { position: relative; }
-    .user-menu-toggle {
-        display: inline-flex; align-items: center; gap: 6px;
-        padding: 6px 12px; font-size: 0.85rem; font-weight: 500; font-family: inherit;
-        color: var(--text-secondary); background: var(--bg-primary);
-        border: 1px solid var(--border-primary); border-radius: 8px;
-        cursor: pointer; transition: color var(--transition-fast), border-color var(--transition-fast);
-        line-height: 1;
-    }
-    .user-menu-toggle:hover, .user-menu-toggle[aria-expanded="true"] {
-        color: var(--text-primary); border-color: var(--border-focus);
-    }
-    .user-menu-chevron { transition: transform var(--transition-fast); }
-    .user-menu-toggle[aria-expanded="true"] .user-menu-chevron { transform: rotate(180deg); }
-    .user-menu-dropdown {
-        display: none; position: absolute; top: calc(100% + 6px); right: 0;
-        min-width: 200px; background: var(--bg-card);
-        border: 1px solid var(--border-primary); border-radius: 8px;
-        box-shadow: var(--shadow-md); padding: 4px 0; z-index: 150;
-    }
-    .user-menu-dropdown.open { display: block; }
-    .user-menu-item {
-        display: flex; align-items: center; gap: 10px; width: 100%;
-        padding: 10px 14px; font-size: 0.8125rem; font-weight: 500; font-family: inherit;
-        color: var(--text-primary); background: none; border: none;
-        text-decoration: none; cursor: pointer;
-        transition: background var(--transition-fast); text-align: left;
-    }
-    .user-menu-item:hover { background: var(--bg-tertiary); }
-    .user-menu-item svg { color: var(--text-tertiary); flex-shrink: 0; }
-    .user-menu-item:hover svg { color: var(--text-secondary); }
-    .user-menu-item-danger { color: var(--status-error); }
-    .user-menu-item-danger svg { color: var(--status-error); }
-    .user-menu-item-danger:hover { background: var(--status-error-bg); }
-    .user-menu-divider { height: 1px; background: var(--border-primary); margin: 4px 0; }
+    {% include '_user_menu.css' %}
 
     .btn {
         display: inline-flex;
@@ -166,22 +131,20 @@
     .btn-sm { padding: 0.25rem 0.625rem; font-size: 0.75rem; }
 
     .theme-toggle {
-        display: inline-flex;
+        background: none;
+        border: none;
+        color: var(--text-secondary);
+        cursor: pointer;
+        padding: 6px;
+        border-radius: 6px;
+        display: flex;
         align-items: center;
         justify-content: center;
-        background: none;
-        border: 1px solid var(--border-primary);
-        border-radius: 0.375rem;
-        padding: 0.375rem 0.5rem;
-        cursor: pointer;
-        color: var(--text-secondary);
-        font-size: 1rem;
-        line-height: 1;
-        transition: color var(--transition-fast), border-color var(--transition-fast);
+        transition: color var(--transition-fast), background-color var(--transition-fast);
     }
     .theme-toggle:hover {
         color: var(--text-primary);
-        border-color: var(--border-focus);
+        background: var(--bg-tertiary);
     }
     [data-theme="dark"] .icon-sun { display: none; }
     [data-theme="light"] .icon-moon { display: none; }
@@ -368,15 +331,15 @@
                         <polyline points="6 9 12 15 18 9"/>
                     </svg>
                 </button>
-                <div class="user-menu-dropdown" id="user-menu-dropdown" role="menu">
-                    <a href="/" class="user-menu-item" role="menuitem">
+                <div class="user-menu-dropdown" id="user-menu-dropdown">
+                    <a href="/" class="user-menu-item">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                             <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/>
                         </svg>
                         Dashboard
                     </a>
                     <div class="user-menu-divider"></div>
-                    <a href="/logout" class="user-menu-item user-menu-item-danger" role="menuitem">
+                    <a href="/logout" class="user-menu-item user-menu-item-danger">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                             <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
                             <polyline points="16 17 21 12 16 7"/>
@@ -682,33 +645,9 @@
         });
     });
 
-    // ---- User Menu Dropdown ----
-    function closeUserMenu() {
-        var dropdown = document.getElementById('user-menu-dropdown');
-        var toggle = document.getElementById('user-menu-toggle');
-        if (dropdown) dropdown.classList.remove('open');
-        if (toggle) toggle.setAttribute('aria-expanded', 'false');
-    }
-    (function() {
-        var toggle = document.getElementById('user-menu-toggle');
-        var dropdown = document.getElementById('user-menu-dropdown');
-        if (!toggle || !dropdown) return;
-        toggle.addEventListener('click', function(e) {
-            e.stopPropagation();
-            var isOpen = dropdown.classList.contains('open');
-            if (isOpen) { closeUserMenu(); } else {
-                dropdown.classList.add('open');
-                toggle.setAttribute('aria-expanded', 'true');
-            }
-        });
-        document.addEventListener('click', function(e) {
-            if (!e.target.closest('#user-menu')) closeUserMenu();
-        });
-        document.addEventListener('keydown', function(e) {
-            if (e.key === 'Escape') { closeUserMenu(); toggle.focus(); }
-        });
-    })();
     </script>
+
+    {% include '_user_menu.js' %}
 
     {% include '_modal.html' %}
 </body>

--- a/src/docsfy/templates/dashboard.html
+++ b/src/docsfy/templates/dashboard.html
@@ -229,60 +229,24 @@
         gap: 0.5rem;
     }
 
-    /* ---- User Menu Dropdown ---- */
-    .user-menu { position: relative; }
-    .user-menu-toggle {
-        display: inline-flex; align-items: center; gap: 6px;
-        padding: 6px 12px; font-size: 0.85rem; font-weight: 500; font-family: inherit;
-        color: var(--text-secondary); background: var(--bg-primary);
-        border: 1px solid var(--border-primary); border-radius: 8px;
-        cursor: pointer; transition: color var(--transition-fast), border-color var(--transition-fast);
-        line-height: 1;
-    }
-    .user-menu-toggle:hover, .user-menu-toggle[aria-expanded="true"] {
-        color: var(--text-primary); border-color: var(--border-focus);
-    }
-    .user-menu-chevron { transition: transform var(--transition-fast); }
-    .user-menu-toggle[aria-expanded="true"] .user-menu-chevron { transform: rotate(180deg); }
-    .user-menu-dropdown {
-        display: none; position: absolute; top: calc(100% + 6px); right: 0;
-        min-width: 200px; background: var(--bg-card);
-        border: 1px solid var(--border-primary); border-radius: 8px;
-        box-shadow: var(--shadow-md); padding: 4px 0; z-index: 150;
-    }
-    .user-menu-dropdown.open { display: block; }
-    .user-menu-item {
-        display: flex; align-items: center; gap: 10px; width: 100%;
-        padding: 10px 14px; font-size: 0.8125rem; font-weight: 500; font-family: inherit;
-        color: var(--text-primary); background: none; border: none;
-        text-decoration: none; cursor: pointer;
-        transition: background var(--transition-fast); text-align: left;
-    }
-    .user-menu-item:hover { background: var(--bg-tertiary); }
-    .user-menu-item svg { color: var(--text-tertiary); flex-shrink: 0; }
-    .user-menu-item:hover svg { color: var(--text-secondary); }
-    .user-menu-item-danger { color: var(--status-error); }
-    .user-menu-item-danger svg { color: var(--status-error); }
-    .user-menu-item-danger:hover { background: var(--status-error-bg); }
-    .user-menu-divider { height: 1px; background: var(--border-primary); margin: 4px 0; }
+    {% include '_user_menu.css' %}
 
     .theme-toggle {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 36px;
-        height: 36px;
-        border: 1px solid var(--border-primary);
-        border-radius: 8px;
-        background: var(--bg-primary);
+        background: none;
+        border: none;
         color: var(--text-secondary);
         cursor: pointer;
-        transition: color var(--transition-fast), border-color var(--transition-fast);
+        padding: 6px;
+        border-radius: 6px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        transition: color var(--transition-fast), background-color var(--transition-fast);
     }
 
     .theme-toggle:hover {
         color: var(--text-primary);
-        border-color: var(--border-focus);
+        background: var(--bg-tertiary);
     }
 
     [data-theme="dark"] .icon-sun { display: none; }
@@ -1322,9 +1286,9 @@
                         <polyline points="6 9 12 15 18 9"/>
                     </svg>
                 </button>
-                <div class="user-menu-dropdown" id="user-menu-dropdown" role="menu">
+                <div class="user-menu-dropdown" id="user-menu-dropdown">
                     {% if role == 'admin' %}
-                    <a href="/admin" class="user-menu-item" role="menuitem">
+                    <a href="/admin" class="user-menu-item">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                             <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/>
                             <circle cx="12" cy="12" r="3"/>
@@ -1332,7 +1296,7 @@
                         Admin Panel
                     </a>
                     {% endif %}
-                    <button class="user-menu-item" role="menuitem" onclick="rotateOwnKey(); closeUserMenu();">
+                    <button class="user-menu-item" onclick="rotateOwnKey(); closeUserMenu();">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                             <rect width="18" height="11" x="3" y="11" rx="2" ry="2"/>
                             <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
@@ -1340,7 +1304,7 @@
                         Change Password
                     </button>
                     <div class="user-menu-divider"></div>
-                    <a href="/logout" class="user-menu-item user-menu-item-danger" role="menuitem">
+                    <a href="/logout" class="user-menu-item user-menu-item-danger">
                         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                             <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
                             <polyline points="16 17 21 12 16 7"/>
@@ -2478,33 +2442,9 @@
             await modalAlert('Error', 'Failed: ' + err.message);
         }
     }
-    // ---- User Menu Dropdown ----
-    function closeUserMenu() {
-        var dropdown = document.getElementById('user-menu-dropdown');
-        var toggle = document.getElementById('user-menu-toggle');
-        if (dropdown) dropdown.classList.remove('open');
-        if (toggle) toggle.setAttribute('aria-expanded', 'false');
-    }
-    (function() {
-        var toggle = document.getElementById('user-menu-toggle');
-        var dropdown = document.getElementById('user-menu-dropdown');
-        if (!toggle || !dropdown) return;
-        toggle.addEventListener('click', function(e) {
-            e.stopPropagation();
-            var isOpen = dropdown.classList.contains('open');
-            if (isOpen) { closeUserMenu(); } else {
-                dropdown.classList.add('open');
-                toggle.setAttribute('aria-expanded', 'true');
-            }
-        });
-        document.addEventListener('click', function(e) {
-            if (!e.target.closest('#user-menu')) closeUserMenu();
-        });
-        document.addEventListener('keydown', function(e) {
-            if (e.key === 'Escape') { closeUserMenu(); toggle.focus(); }
-        });
-    })();
     </script>
+
+    {% include '_user_menu.js' %}
 
     {% include '_modal.html' %}
 </body>


### PR DESCRIPTION
## Summary
- Replaces separate Admin link, username text, Change Password button, and Logout link with a single clickable username dropdown menu
- Dashboard dropdown: Admin Panel (conditional), Change Password, Logout
- Admin panel dropdown: Dashboard, Logout
- Theme toggle remains separate
- Consistent styling matching the theme toggle (bordered pill, 8px radius)

## Changes
- `src/docsfy/templates/dashboard.html` - CSS, HTML, JS for dropdown menu
- `src/docsfy/templates/admin.html` - CSS, HTML, JS for dropdown menu

## Test plan
- [x] All 150 tests passing
- [ ] Dashboard as admin: dropdown shows Admin Panel, Change Password, Logout
- [ ] Dashboard as regular user: dropdown shows Change Password, Logout (no Admin Panel)
- [ ] Admin panel: dropdown shows Dashboard, Logout
- [ ] Click-outside and Escape key close dropdown
- [ ] Change Password opens modal and closes dropdown
- [ ] Works in both light and dark themes

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replaced header user controls with an interactive dropdown menu displaying your username
  * Menu provides quick access to Admin Panel (for admin users), Change Password, and Logout options
  * Enhanced interactions: toggle menu on click, close with Escape key or outside click
  * Improved visual design with hover states and toggle indicator showing menu state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->