### PR TITLE
fix: Admin users get 409 on status page for their own projects

### DIFF
--- a/src/docsfy/main.py
+++ b/src/docsfy/main.py
@@ -218,18 +218,17 @@ async def _resolve_project(
 
     Raises 404 if not found or not accessible.
     """
-    # 1. Try owned by requesting user
-    if not request.state.is_admin:
-        proj = await get_project(
-            name,
-            ai_provider=ai_provider,
-            ai_model=ai_model,
-            owner=request.state.username,
-        )
-        if proj:
-            return proj
+    # 1. Try owned by requesting user (including admin)
+    proj = await get_project(
+        name,
+        ai_provider=ai_provider,
+        ai_model=ai_model,
+        owner=request.state.username,
+    )
+    if proj:
+        return proj
 
-    # 2. For admin, disambiguate by owner
+    # 2. For admin, disambiguate by owner (fallback when admin doesn't own it)
     if request.state.is_admin:
         all_variants = await list_variants(name)
         matching = [


### PR DESCRIPTION
## Summary
- Admin users viewing the status page for their own projects got `409 Multiple owners found` error
- Root cause: `_resolve_project()` skipped the owner-first lookup for admins, going straight to cross-owner disambiguation
- Fix: All users (including admin) now try their own variant first before falling back

## Changes
- `src/docsfy/main.py` - Removed `if not request.state.is_admin` guard on owner-first lookup in `_resolve_project()`

## Test plan
- [x] All 150 tests passing
- [ ] Admin user can view status page for their own project without 409

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved project resolution logic for more consistent behavior across user types during project lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->