### PR TITLE
fix: combobox dropdowns clipped by parent overflow

### DIFF
--- a/src/docsfy/templates/dashboard.html
+++ b/src/docsfy/templates/dashboard.html
@@ -465,7 +465,6 @@
         border: 1px solid var(--border-primary);
         border-radius: 8px;
         margin-bottom: 1rem;
-        overflow: hidden;
     }
 
     .group-header {
@@ -474,6 +473,7 @@
         gap: 0.75rem;
         padding: 1rem 1.25rem;
         border-bottom: 1px solid var(--border-primary);
+        border-radius: 8px 8px 0 0;
         background: var(--bg-secondary);
         cursor: pointer;
     }
@@ -483,6 +483,15 @@
         color: var(--text-tertiary);
         flex-shrink: 0;
     }
+    .project-group > :last-child {
+        border-radius: 0 0 8px 8px;
+    }
+
+    .project-group.collapsed .group-header {
+        border-radius: 8px;
+        border-bottom: none;
+    }
+
     .project-group.collapsed .group-toggle-icon {
         transform: rotate(-90deg);
     }


### PR DESCRIPTION
## Summary
- Removed `overflow: hidden` from `.project-group` which was clipping absolutely-positioned combobox dropdowns
- Applied `border-radius` directly to first/last children to maintain rounded corners
- Collapsed state gets full border-radius on group header

Closes #23

## Test plan
- [ ] Branch combobox dropdown in regenerate controls renders fully visible
- [ ] Model combobox dropdown in regenerate controls renders fully visible
- [ ] Collapsed project groups still have rounded corners
- [ ] Generate form comboboxes unaffected (already working)
- [ ] Both light and dark themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated project group headers with rounded corners for a polished appearance.
  * Refined styling for collapsed project groups to maintain visual consistency with improved corner rounding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->