### PR TITLE
fix: toast dark theme, CLI non-JSON handling, redirect detection

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,12 +3,15 @@ import { Toaster } from 'sonner'
 import LoginPage from '@/pages/LoginPage'
 import DashboardPage from '@/pages/DashboardPage'
 import ModalProvider from '@/components/shared/ModalProvider'
+import { useTheme } from '@/lib/useTheme'
 
 function App() {
+  const { theme } = useTheme()
+
   return (
     <BrowserRouter>
       <ModalProvider>
-        <Toaster position="top-right" closeButton />
+        <Toaster position="top-right" closeButton theme={theme} />
         <Routes>
           <Route path="/login" element={<LoginPage />} />
           <Route path="/" element={<DashboardPage />} />

--- a/src/docsfy/cli/client.py
+++ b/src/docsfy/cli/client.py
@@ -73,6 +73,13 @@ class DocsfyClient:
 
     def _check_error(self, response: httpx.Response) -> None:
         """Print error details and exit on HTTP errors."""
+        if response.is_redirect:
+            location = response.headers.get("location", "?")
+            typer.echo(
+                f"Error: Server redirected to {location}. Check the server URL.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
         if response.status_code >= 400:
             try:
                 detail = response.json().get("detail", response.reason_phrase)

--- a/src/docsfy/cli/main.py
+++ b/src/docsfy/cli/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, Any, Optional
 
 import typer
@@ -80,9 +81,22 @@ def health() -> None:
     client = get_client()
     try:
         response = client.get("/health")
-        data = response.json()
+        try:
+            data = response.json()
+        except (json.JSONDecodeError, ValueError):
+            typer.echo(f"Server: {client.server_url}")
+            typer.echo(
+                f"Status: responded but returned non-JSON (status {response.status_code})"
+            )
+            typer.echo(f"Response: {response.text[:200]}")
+            raise typer.Exit(code=1)
         typer.echo(f"Server: {client.server_url}")
         typer.echo(f"Status: {data.get('status', 'unknown')}")
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        typer.echo(f"Server unreachable: {exc}", err=True)
+        raise typer.Exit(code=1)
     finally:
         client.close()
 


### PR DESCRIPTION
## Summary

- Toast notifications now respect dark/light theme via Sonner theme prop
- CLI health command handles non-JSON responses gracefully (no more crash on HTML)
- DocsfyClient detects HTTP redirects instead of crashing on HTML bodies

## Test plan

- [x] Frontend builds
- [x] 289 Python tests pass
- [x] Toast respects dark theme
- [x] CLI handles non-JSON server responses

@coderabbitai do not review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Toast notifications now adapt to the current theme.

* **Bug Fixes**
  * Improved error messages for HTTP redirects, including redirect destination.
  * Enhanced server health diagnostics with clearer error reporting for non-JSON responses and unreachable servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->