### PR TITLE
chore: bump docsfy to 1.0.2 in lock file

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -95,7 +95,7 @@ wheels = [
 
 [[package]]
 name = "docsfy"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "ai-cli-runner" },


### PR DESCRIPTION
Update uv.lock to reflect version 1.0.2