### PR TITLE
feat: add docsfy models command to list available providers and models

### DIFF
--- a/src/docsfy/api/projects.py
+++ b/src/docsfy/api/projects.py
@@ -1156,7 +1156,11 @@ async def get_models_endpoint() -> dict[str, Any]:
     No authentication required -- this is a discovery endpoint.
     """
     settings = get_settings()
-    known_models = await get_known_models()
+    try:
+        known_models = await get_known_models()
+    except Exception as exc:
+        logger.warning(f"/api/models: failed to load known_models: {exc}")
+        known_models = {}
     return {
         "providers": list(VALID_PROVIDERS),
         "default_provider": settings.ai_provider,

--- a/src/docsfy/api/projects.py
+++ b/src/docsfy/api/projects.py
@@ -1149,6 +1149,22 @@ async def build_projects_payload(username: str, is_admin: bool) -> dict[str, Any
     }
 
 
+@router.get("/models")
+async def get_models_endpoint() -> dict[str, Any]:
+    """Return available AI providers, server defaults, and known models.
+
+    No authentication required -- this is a discovery endpoint.
+    """
+    settings = get_settings()
+    known_models = await get_known_models()
+    return {
+        "providers": list(VALID_PROVIDERS),
+        "default_provider": settings.ai_provider,
+        "default_model": settings.ai_model,
+        "known_models": known_models,
+    }
+
+
 @router.get("/status")
 @router.get("/projects")
 async def status(request: Request) -> dict[str, Any]:

--- a/src/docsfy/cli/client.py
+++ b/src/docsfy/cli/client.py
@@ -42,6 +42,11 @@ class DocsfyClient:
         self._check_error(response)
         return response
 
+    def get_models(self) -> dict[str, Any]:
+        """Fetch available AI providers and known models."""
+        response = self.get("/api/models")
+        return response.json()
+
     def download(self, path: str, output_path: Path) -> None:
         """Stream-download a file to the given path using atomic write."""
         import tempfile

--- a/src/docsfy/cli/main.py
+++ b/src/docsfy/cli/main.py
@@ -65,7 +65,7 @@ def main_callback(
 
 # Import standalone commands after app is defined to avoid circular imports
 from docsfy.cli.generate import generate  # noqa: E402
-from docsfy.cli.projects import abort, delete, download, list_projects, status  # noqa: E402
+from docsfy.cli.projects import abort, delete, download, list_projects, models, status  # noqa: E402
 
 app.command("generate")(generate)
 app.command("list")(list_projects)
@@ -73,6 +73,7 @@ app.command("status")(status)
 app.command("delete")(delete)
 app.command("abort")(abort)
 app.command("download")(download)
+app.command("models")(models)
 
 
 @app.command("health")

--- a/src/docsfy/cli/projects.py
+++ b/src/docsfy/cli/projects.py
@@ -334,6 +334,10 @@ def models(
         Optional[str],
         typer.Option("--provider", "-P", help="Filter by provider"),
     ] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", "-j", help="Output as JSON"),
+    ] = False,
 ) -> None:
     """List available AI providers and known models."""
     from docsfy.cli.main import get_client
@@ -353,6 +357,21 @@ def models(
         if provider not in providers:
             typer.echo(f"Unknown provider: {provider}")
             raise typer.Exit(1)
+
+    if json_output:
+        if provider:
+            filtered = {
+                "providers": [provider],
+                "default_provider": default_provider,
+                "default_model": default_model,
+                "known_models": {provider: known.get(provider, [])},
+            }
+            typer.echo(json.dumps(filtered, indent=2))
+        else:
+            typer.echo(json.dumps(data, indent=2))
+        return
+
+    if provider:
         providers = [provider]
 
     for p in providers:

--- a/src/docsfy/cli/projects.py
+++ b/src/docsfy/cli/projects.py
@@ -4,7 +4,7 @@ import json
 import tarfile
 import tempfile
 from pathlib import Path
-from typing import Any, Optional
+from typing import Annotated, Any, Optional
 
 import typer
 
@@ -327,3 +327,49 @@ def download(
             typer.echo(f"Downloaded to {dest}")
     finally:
         client.close()
+
+
+def models(
+    provider: Annotated[
+        Optional[str],
+        typer.Option("--provider", "-P", help="Filter by provider"),
+    ] = None,
+) -> None:
+    """List available AI providers and known models."""
+    from docsfy.cli.main import get_client
+
+    client = get_client()
+    try:
+        data = client.get_models()
+    finally:
+        client.close()
+
+    providers = data.get("providers", [])
+    default_provider = data.get("default_provider", "")
+    default_model = data.get("default_model", "")
+    known = data.get("known_models", {})
+
+    if provider:
+        if provider not in providers:
+            typer.echo(f"Unknown provider: {provider}")
+            raise typer.Exit(1)
+        providers = [provider]
+
+    for p in providers:
+        label = f"Provider: {p}"
+        if p == default_provider:
+            label += " (default)"
+        typer.echo(label)
+
+        models_list = known.get(p, [])
+        if not models_list:
+            typer.echo("  (no models used yet)")
+        else:
+            for m in models_list:
+                suffix = (
+                    "  (default)"
+                    if p == default_provider and m == default_model
+                    else ""
+                )
+                typer.echo(f"  {m}{suffix}")
+        typer.echo()

--- a/src/docsfy/main.py
+++ b/src/docsfy/main.py
@@ -83,6 +83,8 @@ class AuthMiddleware(BaseHTTPMiddleware):
             "/api/auth/login/",
             "/api/auth/logout",
             "/api/auth/logout/",
+            "/api/models",
+            "/api/models/",
             "/api/ws",
             "/health",
             "/login",

--- a/test-plans/e2e-14-models-command.md
+++ b/test-plans/e2e-14-models-command.md
@@ -1,0 +1,186 @@
+# E2E Tests: Models Command
+
+> Back to the [main E2E index](e2e-ui-test-plan.md#test-files). Shared execution rules, prerequisites, variables, and environment constraints live there.
+
+> **Note:** These tests exercise the `docsfy models` CLI command and the `GET /api/models` API endpoint. The server must be running at `http://localhost:8800`.
+
+---
+
+## Test 28: Models Command
+
+### Prerequisites
+
+Set up the CLI configuration:
+```shell
+export DOCSFY_SERVER="http://localhost:8800"
+export DOCSFY_API_KEY="<ADMIN_KEY>"
+```
+
+### 28.1 Models returns providers list with defaults marked
+
+**Commands:**
+```shell
+docsfy models
+```
+
+**Expected result:**
+- The output lists all known providers (e.g., `claude`, `gemini`, `cursor`)
+- The server's default provider is marked with `(default)` next to its name
+- The server's default model is marked with `(default)` next to its name under the default provider
+- Each provider section shows its known models or `(no models used yet)` if none exist
+
+---
+
+### 28.2 Models filters to single provider
+
+**Commands:**
+```shell
+docsfy models --provider cursor
+```
+
+**Expected result:**
+- Only the `cursor` provider is listed
+- No other providers appear in the output
+- If `cursor` has known models from completed generations, they are shown
+- If not, `(no models used yet)` is displayed
+
+---
+
+### 28.3 Models with invalid provider returns error
+
+**Commands:**
+```shell
+docsfy models --provider invalid
+echo "Exit code: $?"
+```
+
+**Expected result:**
+- The output contains `Unknown provider: invalid`
+- The exit code is non-zero (1)
+
+---
+
+### 28.4 Models JSON output returns valid JSON
+
+**Commands:**
+```shell
+docsfy models --json
+```
+
+**Check:**
+```shell
+docsfy models --json | python3 -c "import sys,json; data=json.load(sys.stdin); assert 'providers' in data; assert 'default_provider' in data; assert 'default_model' in data; assert 'known_models' in data; print('Valid JSON with all required keys')"
+```
+
+**Expected result:**
+- The output is valid JSON
+- The JSON contains the keys `providers`, `default_provider`, `default_model`, and `known_models`
+- `providers` is a list containing the known provider names (e.g., `["claude", "gemini", "cursor"]`)
+- `default_provider` is a string matching one of the providers
+- `default_model` is a string
+- `known_models` is an object keyed by provider name
+
+---
+
+### 28.5 Models JSON output with provider filter
+
+**Commands:**
+```shell
+docsfy models --json --provider gemini
+```
+
+**Check:**
+```shell
+docsfy models --json --provider gemini | python3 -c "import sys,json; data=json.load(sys.stdin); assert data['providers'] == ['gemini'], f'Expected [\"gemini\"], got {data[\"providers\"]}'; assert list(data['known_models'].keys()) == ['gemini'], f'Expected only gemini key in known_models, got {list(data[\"known_models\"].keys())}'; print('Filtered JSON is correct')"
+```
+
+**Expected result:**
+- The JSON output contains only `gemini` in the `providers` list
+- The `known_models` object contains only the `gemini` key
+- `default_provider` and `default_model` are still present (they reflect the server defaults, not the filter)
+
+---
+
+### 28.6 API endpoint is accessible without authentication
+
+**Commands:**
+```shell
+curl -s -o /dev/null -w "%{http_code}" "$DOCSFY_SERVER/api/models"
+```
+
+**Expected result:**
+- The HTTP status code is `200`
+- No `Authorization` header is required
+
+**Verify response body:**
+```shell
+curl -s "$DOCSFY_SERVER/api/models" | python3 -c "import sys,json; data=json.load(sys.stdin); assert 'providers' in data; assert 'default_provider' in data; assert 'default_model' in data; assert 'known_models' in data; print('API response is valid')"
+```
+
+**Expected result:**
+- The response is valid JSON with the same schema as the CLI `--json` output
+- Contains `providers`, `default_provider`, `default_model`, and `known_models`
+
+---
+
+### 28.7 Response includes known_models from completed generations
+
+**Precondition:** At least one generation must have completed successfully. If no prior test has generated docs, trigger one first.
+
+**Check for existing completed generation:**
+```shell
+COMPLETED=$(curl -s "$DOCSFY_SERVER/api/models" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+known = data.get('known_models', {})
+total = sum(len(v) for v in known.values())
+print(total)
+")
+echo "Known models count: $COMPLETED"
+```
+
+If 0, generate docs to populate known_models:
+```shell
+if [ "$COMPLETED" = "0" ]; then
+  docsfy generate https://github.com/myk-org/for-testing-only --provider gemini --model gemini-2.5-flash --force
+  for i in $(seq 1 60); do
+    STATUS=$(curl -s "$DOCSFY_SERVER/api/projects" -H "Authorization: Bearer $DOCSFY_API_KEY" | python3 -c "import sys,json; data=json.load(sys.stdin); matches=[p for p in data['projects'] if p['name']=='for-testing-only' and p['branch']=='main' and p['ai_model']=='gemini-2.5-flash']; print(matches[0].get('status','') if matches else 'not_found')")
+    echo "Poll $i: status=$STATUS"
+    if [ "$STATUS" = "ready" ] || [ "$STATUS" = "error" ] || [ "$STATUS" = "aborted" ]; then break; fi
+    sleep 2
+  done
+fi
+```
+
+**Verify known_models contains data:**
+```shell
+curl -s "$DOCSFY_SERVER/api/models" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+known = data.get('known_models', {})
+assert isinstance(known, dict), 'known_models should be a dict'
+total = sum(len(v) for v in known.values())
+assert total > 0, 'known_models should contain at least one model after generation'
+# Verify the model we generated with is present
+gemini_models = known.get('gemini', [])
+assert 'gemini-2.5-flash' in gemini_models, f'Expected gemini-2.5-flash in known gemini models, got {gemini_models}'
+print(f'known_models contains {total} model(s) across {len(known)} provider(s)')
+print(f'gemini models: {gemini_models}')
+"
+```
+
+**Expected result:**
+- `known_models` is a dictionary keyed by provider name
+- The `gemini` key contains `gemini-2.5-flash` (from the completed generation)
+- Models from completed generations are accurately reflected in the response
+
+---
+
+### 28.8 Cleanup
+
+**Delete any generation created by test 28.7:**
+```shell
+docsfy delete for-testing-only --branch main --provider gemini --model gemini-2.5-flash --yes 2>/dev/null || true
+```
+
+**Expected result:** Variant is deleted or already gone.

--- a/test-plans/e2e-14-models-command.md
+++ b/test-plans/e2e-14-models-command.md
@@ -1,7 +1,6 @@
 # E2E Tests: Models Command
 
 > Back to the [main E2E index](e2e-ui-test-plan.md#test-files). Shared execution rules, prerequisites, variables, and environment constraints live there.
-
 > **Note:** These tests exercise the `docsfy models` CLI command and the `GET /api/models` API endpoint. The server must be running at `http://localhost:8800`.
 
 ---
@@ -11,6 +10,7 @@
 ### Prerequisites
 
 Set up the CLI configuration:
+
 ```shell
 export DOCSFY_SERVER="http://localhost:8800"
 export DOCSFY_API_KEY="<ADMIN_KEY>"
@@ -19,6 +19,7 @@ export DOCSFY_API_KEY="<ADMIN_KEY>"
 ### 28.1 Models returns providers list with defaults marked
 
 **Commands:**
+
 ```shell
 docsfy models
 ```
@@ -34,6 +35,7 @@ docsfy models
 ### 28.2 Models filters to single provider
 
 **Commands:**
+
 ```shell
 docsfy models --provider cursor
 ```
@@ -49,6 +51,7 @@ docsfy models --provider cursor
 ### 28.3 Models with invalid provider returns error
 
 **Commands:**
+
 ```shell
 docsfy models --provider invalid
 echo "Exit code: $?"
@@ -63,11 +66,13 @@ echo "Exit code: $?"
 ### 28.4 Models JSON output returns valid JSON
 
 **Commands:**
+
 ```shell
 docsfy models --json
 ```
 
 **Check:**
+
 ```shell
 docsfy models --json | python3 -c "import sys,json; data=json.load(sys.stdin); assert 'providers' in data; assert 'default_provider' in data; assert 'default_model' in data; assert 'known_models' in data; print('Valid JSON with all required keys')"
 ```
@@ -85,11 +90,13 @@ docsfy models --json | python3 -c "import sys,json; data=json.load(sys.stdin); a
 ### 28.5 Models JSON output with provider filter
 
 **Commands:**
+
 ```shell
 docsfy models --json --provider gemini
 ```
 
 **Check:**
+
 ```shell
 docsfy models --json --provider gemini | python3 -c "import sys,json; data=json.load(sys.stdin); assert data['providers'] == ['gemini'], f'Expected [\"gemini\"], got {data[\"providers\"]}'; assert list(data['known_models'].keys()) == ['gemini'], f'Expected only gemini key in known_models, got {list(data[\"known_models\"].keys())}'; print('Filtered JSON is correct')"
 ```
@@ -104,6 +111,7 @@ docsfy models --json --provider gemini | python3 -c "import sys,json; data=json.
 ### 28.6 API endpoint is accessible without authentication
 
 **Commands:**
+
 ```shell
 curl -s -o /dev/null -w "%{http_code}" "$DOCSFY_SERVER/api/models"
 ```
@@ -113,6 +121,7 @@ curl -s -o /dev/null -w "%{http_code}" "$DOCSFY_SERVER/api/models"
 - No `Authorization` header is required
 
 **Verify response body:**
+
 ```shell
 curl -s "$DOCSFY_SERVER/api/models" | python3 -c "import sys,json; data=json.load(sys.stdin); assert 'providers' in data; assert 'default_provider' in data; assert 'default_model' in data; assert 'known_models' in data; print('API response is valid')"
 ```
@@ -128,6 +137,7 @@ curl -s "$DOCSFY_SERVER/api/models" | python3 -c "import sys,json; data=json.loa
 **Precondition:** At least one generation must have completed successfully. If no prior test has generated docs, trigger one first.
 
 **Check for existing completed generation:**
+
 ```shell
 COMPLETED=$(curl -s "$DOCSFY_SERVER/api/models" | python3 -c "
 import sys, json
@@ -140,6 +150,7 @@ echo "Known models count: $COMPLETED"
 ```
 
 If 0, generate docs to populate known_models:
+
 ```shell
 if [ "$COMPLETED" = "0" ]; then
   docsfy generate https://github.com/myk-org/for-testing-only --provider gemini --model gemini-2.5-flash --force
@@ -153,6 +164,7 @@ fi
 ```
 
 **Verify known_models contains data:**
+
 ```shell
 curl -s "$DOCSFY_SERVER/api/models" | python3 -c "
 import sys, json
@@ -179,6 +191,7 @@ print(f'gemini models: {gemini_models}')
 ### 28.8 Cleanup
 
 **Delete any generation created by test 28.7:**
+
 ```shell
 docsfy delete for-testing-only --branch main --provider gemini --model gemini-2.5-flash --yes 2>/dev/null || true
 ```

--- a/test-plans/e2e-ui-test-plan.md
+++ b/test-plans/e2e-ui-test-plan.md
@@ -164,6 +164,7 @@ Each linked sub-file contains only the detailed test bodies for its assigned sec
 | [e2e-11-websocket.md](e2e-11-websocket.md) | 23 | WebSocket Connection, Auth, Real-time Updates |
 | [e2e-12-cli.md](e2e-12-cli.md) | 24 | CLI Commands (config, generate, list, status, admin) |
 | [e2e-13-post-generation-pipeline.md](e2e-13-post-generation-pipeline.md) | 27 | Post-Generation Pipeline (version footer, Mermaid diagrams, related pages, validation/cross-linking stages, performance) |
+| [e2e-14-models-command.md](e2e-14-models-command.md) | 28 | Models Command (CLI providers/models listing, JSON output, API endpoint, known_models) |
 | [e2e-09-cleanup.md](e2e-09-cleanup.md) | 21 | Cleanup and Teardown |
 
 **`e2e-09-cleanup.md` must always be executed last, after all other test files.**
@@ -200,4 +201,5 @@ Each linked sub-file contains only the detailed test bodies for its assigned sec
 | 25 | Sidebar Collapse Toggle Position | 25.1-25.4 |
 | 26 | Dialog Theme Consistency | 26.1-26.2 |
 | 27 | Post-Generation Pipeline | 27.1-27.8 |
+| 28 | Models Command | 28.1-28.8 |
 | 21 | Cleanup and Teardown | 21.1-21.5 |

--- a/tests/test_api_projects.py
+++ b/tests/test_api_projects.py
@@ -85,3 +85,69 @@ async def test_get_project_not_found(client: AsyncClient) -> None:
     """GET /api/projects/nonexistent returns 404."""
     response = await client.get("/api/projects/nonexistent")
     assert response.status_code == 404
+
+
+async def test_get_models_returns_valid_structure(client: AsyncClient) -> None:
+    """GET /api/models returns providers, defaults, and known_models."""
+    response = await client.get("/api/models")
+    assert response.status_code == 200
+    data = response.json()
+    assert "providers" in data
+    assert "default_provider" in data
+    assert "default_model" in data
+    assert "known_models" in data
+    assert isinstance(data["providers"], list)
+    assert isinstance(data["known_models"], dict)
+
+
+async def test_get_models_includes_valid_providers(client: AsyncClient) -> None:
+    """GET /api/models providers list matches VALID_PROVIDERS."""
+    from docsfy.models import VALID_PROVIDERS
+
+    response = await client.get("/api/models")
+    data = response.json()
+    assert data["providers"] == list(VALID_PROVIDERS)
+
+
+async def test_get_models_no_auth_required() -> None:
+    """GET /api/models works without authentication."""
+    import docsfy.storage as storage
+    from docsfy.config import get_settings
+
+    # Use a temporary path to avoid interfering with other tests
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        orig_db = storage.DB_PATH
+        orig_data = storage.DATA_DIR
+        orig_projects = storage.PROJECTS_DIR
+
+        storage.DB_PATH = tmp_path / "test.db"
+        storage.DATA_DIR = tmp_path
+        storage.PROJECTS_DIR = tmp_path / "projects"
+
+        get_settings.cache_clear()
+
+        from docsfy.main import app
+
+        try:
+            with patch.dict(os.environ, {"ADMIN_KEY": TEST_ADMIN_KEY}):
+                get_settings.cache_clear()
+                await storage.init_db()
+                transport = ASGITransport(app=app)
+                # No Authorization header -- unauthenticated request
+                async with AsyncClient(
+                    transport=transport,
+                    base_url="http://test",
+                ) as ac:
+                    response = await ac.get("/api/models")
+                    assert response.status_code == 200
+                    data = response.json()
+                    assert "providers" in data
+        finally:
+            storage.DB_PATH = orig_db
+            storage.DATA_DIR = orig_data
+            storage.PROJECTS_DIR = orig_projects
+            get_settings.cache_clear()

--- a/tests/test_api_projects.py
+++ b/tests/test_api_projects.py
@@ -105,6 +105,7 @@ async def test_get_models_includes_valid_providers(client: AsyncClient) -> None:
     from docsfy.models import VALID_PROVIDERS
 
     response = await client.get("/api/models")
+    assert response.status_code == 200
     data = response.json()
     assert data["providers"] == list(VALID_PROVIDERS)
 

--- a/tests/test_cli_projects.py
+++ b/tests/test_cli_projects.py
@@ -390,6 +390,42 @@ class TestModels:
         assert result.exit_code == 0
         assert "(no models used yet)" in result.output
 
+    def test_models_json_output(self, mock_client: MagicMock) -> None:
+        api_data = {
+            "providers": ["claude", "gemini", "cursor"],
+            "default_provider": "cursor",
+            "default_model": "gpt-5.4-xhigh-fast",
+            "known_models": {
+                "cursor": ["gpt-5.4-xhigh-fast"],
+                "claude": ["sonnet-4"],
+            },
+        }
+        mock_client.get_models.return_value = api_data
+        result = runner.invoke(app, ["models", "--json"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data == api_data
+
+    def test_models_json_filtered_by_provider(self, mock_client: MagicMock) -> None:
+        mock_client.get_models.return_value = {
+            "providers": ["claude", "gemini", "cursor"],
+            "default_provider": "cursor",
+            "default_model": "gpt-5.4-xhigh-fast",
+            "known_models": {
+                "cursor": ["gpt-5.4-xhigh-fast"],
+                "claude": ["sonnet-4"],
+            },
+        }
+        result = runner.invoke(app, ["models", "--json", "--provider", "claude"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["providers"] == ["claude"]
+        assert data["default_provider"] == "cursor"
+        assert data["default_model"] == "gpt-5.4-xhigh-fast"
+        assert data["known_models"] == {"claude": ["sonnet-4"]}
+        # Must not contain other providers' models
+        assert "cursor" not in data["known_models"]
+
 
 class TestDownload:
     def test_download_to_file(self, mock_client: MagicMock, tmp_path: Path) -> None:

--- a/tests/test_cli_projects.py
+++ b/tests/test_cli_projects.py
@@ -313,6 +313,84 @@ class TestGenerate:
         assert "dev" in result.output
 
 
+class TestModels:
+    def test_models_lists_providers(self, mock_client: MagicMock) -> None:
+        mock_client.get_models.return_value = {
+            "providers": ["claude", "gemini", "cursor"],
+            "default_provider": "cursor",
+            "default_model": "gpt-5.4-xhigh-fast",
+            "known_models": {
+                "cursor": ["gpt-5.4-xhigh-fast"],
+                "claude": ["sonnet-4"],
+            },
+        }
+        result = runner.invoke(app, ["models"])
+        assert result.exit_code == 0
+        assert "claude" in result.output
+        assert "gemini" in result.output
+        assert "cursor" in result.output
+
+    def test_models_shows_default_markers(self, mock_client: MagicMock) -> None:
+        mock_client.get_models.return_value = {
+            "providers": ["claude", "cursor"],
+            "default_provider": "cursor",
+            "default_model": "gpt-5.4-xhigh-fast",
+            "known_models": {
+                "cursor": ["gpt-5.4-xhigh-fast", "gpt-4"],
+            },
+        }
+        result = runner.invoke(app, ["models"])
+        assert result.exit_code == 0
+        # Provider marked as default
+        assert "Provider: cursor (default)" in result.output
+        # Model marked as default
+        assert "gpt-5.4-xhigh-fast  (default)" in result.output
+        # Non-default model has no marker
+        lines = result.output.strip().split("\n")
+        gpt4_lines = [line for line in lines if "gpt-4" in line]
+        assert gpt4_lines
+        assert "(default)" not in gpt4_lines[0]
+
+    def test_models_filter_by_provider(self, mock_client: MagicMock) -> None:
+        mock_client.get_models.return_value = {
+            "providers": ["claude", "gemini", "cursor"],
+            "default_provider": "cursor",
+            "default_model": "gpt-5.4-xhigh-fast",
+            "known_models": {
+                "claude": ["sonnet-4"],
+                "cursor": ["gpt-5.4-xhigh-fast"],
+            },
+        }
+        result = runner.invoke(app, ["models", "--provider", "claude"])
+        assert result.exit_code == 0
+        assert "claude" in result.output
+        assert "cursor" not in result.output.lower().replace("provider: cursor", "")
+        # Only claude provider section should appear
+        assert "Provider: claude" in result.output
+
+    def test_models_filter_unknown_provider(self, mock_client: MagicMock) -> None:
+        mock_client.get_models.return_value = {
+            "providers": ["claude", "gemini", "cursor"],
+            "default_provider": "cursor",
+            "default_model": "gpt-5.4-xhigh-fast",
+            "known_models": {},
+        }
+        result = runner.invoke(app, ["models", "--provider", "invalid"])
+        assert result.exit_code == 1
+        assert "Unknown provider" in result.output
+
+    def test_models_no_models_yet(self, mock_client: MagicMock) -> None:
+        mock_client.get_models.return_value = {
+            "providers": ["claude", "gemini", "cursor"],
+            "default_provider": "cursor",
+            "default_model": "gpt-5.4-xhigh-fast",
+            "known_models": {},
+        }
+        result = runner.invoke(app, ["models"])
+        assert result.exit_code == 0
+        assert "(no models used yet)" in result.output
+
+
 class TestDownload:
     def test_download_to_file(self, mock_client: MagicMock, tmp_path: Path) -> None:
         # Mock the download method to write fake data


### PR DESCRIPTION
## Summary

Closes #43

Adds a `docsfy models` CLI command and `GET /api/models` endpoint for discovering available AI providers and models.

- `docsfy models` — lists all providers with known models, marks defaults
- `docsfy models --provider claude` — filter by provider
- `docsfy models --json` — machine-readable JSON output for AI agent integration
- `GET /api/models` — public endpoint (no auth required), returns providers, defaults, and known models

## Changes

- `src/docsfy/api/projects.py` — new `/api/models` endpoint
- `src/docsfy/main.py` — added `/api/models` to public paths (no auth)
- `src/docsfy/cli/projects.py` — new `models` command with `--provider` and `--json` flags
- `src/docsfy/cli/client.py` — `get_models()` client method
- `src/docsfy/cli/main.py` — registered models command

## Test plan

- [x] 3 API tests (structure, providers, no-auth)
- [x] 7 CLI tests (listing, defaults, filter, JSON, error cases)
- [x] E2E test plan added (test-plans/e2e-14-models-command.md)
- [x] Peer reviewed with Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `docsfy models` CLI command (filter by `--provider`, JSON via `--json`) and a public `/api/models` endpoint for provider/model discovery.

* **Documentation**
  * Added an end-to-end test plan describing CLI and API behaviors for the models command and endpoint.

* **Tests**
  * Added unit and integration tests covering the `/api/models` endpoint and the CLI `models` command (including JSON and error cases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->