### PR TITLE
feat(skill): support uvx docsfy fallback when CLI not installed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,1 +1,1 @@
-/home/myakove/git/docsfy/CLAUDE.md
+CLAUDE.md

--- a/skills/docsfy-generate-docs/SKILL.md
+++ b/skills/docsfy-generate-docs/SKILL.md
@@ -11,18 +11,14 @@ Generate AI-powered documentation for a Git repository using the docsfy CLI. The
 
 ## Prerequisites (MANDATORY - check before anything else)
 
-### 1. docsfy CLI available
-
-Check if `docsfy` is installed:
+### 1. Check docsfy CLI
 
 ```bash
 docsfy --help
 ```
 
-- If found: use `docsfy` as the command throughout this workflow.
-- If NOT found: use `uvx docsfy` instead — this runs docsfy on-the-fly via uv without requiring installation. Verify `uvx` is available (`uvx --help`). If neither `docsfy` nor `uvx` is available, inform the user they need to install either docsfy (`uv tool install docsfy`) or uv (which provides `uvx`).
-
-**For the rest of this document, `docsfy` refers to whichever command is available (`docsfy` or `uvx docsfy`).** All example commands show `docsfy` — substitute `uvx docsfy` if that's what's being used.
+If not found, use `uvx docsfy` as the command prefix for all `docsfy` commands in this document.
+If `uvx` is also not available: `uv tool install docsfy`
 
 ### 2. Server is alive
 
@@ -31,7 +27,7 @@ docsfy health
 ```
 
 If health check fails, inform the user that the docsfy server is not reachable and stop. The user may need to:
-- Start the server: `docsfy-server` (or `uvx --from docsfy docsfy-server` if not installed — note: `docsfy-server` is a separate entry point in the same package; bare `uvx docsfy-server` will not work)
+- Start the server: `docsfy-server` (or `uvx --from docsfy docsfy-server`)
 - Check their config: `docsfy config show`
 - Set up a profile: `docsfy config init`
 
@@ -110,7 +106,7 @@ Display:
 
 ## Quick Reference
 
-> **Note:** If `docsfy` is not installed, replace `docsfy` with `uvx docsfy` in all commands below.
+> If `docsfy` is not installed, prefix commands with `uvx` (e.g., `uvx docsfy health`).
 
 | Command | Purpose |
 |---------|---------|
@@ -133,4 +129,4 @@ Display:
 | Forgetting `--watch` flag | Always use `--watch` for real-time progress |
 | Downloading before ready | Check status is `ready` before downloading |
 | Leaving nested download folder | Flatten after download — move files to output root |
-| Requiring docsfy installation in containers | Use `uvx docsfy` when docsfy isn't installed but uv is available |
+| Assuming docsfy is installed | Use `uvx docsfy` when CLI is missing but uv is available |

--- a/skills/docsfy-generate-docs/SKILL.md
+++ b/skills/docsfy-generate-docs/SKILL.md
@@ -11,13 +11,18 @@ Generate AI-powered documentation for a Git repository using the docsfy CLI. The
 
 ## Prerequisites (MANDATORY - check before anything else)
 
-### 1. docsfy CLI installed
+### 1. docsfy CLI available
+
+Check if `docsfy` is installed:
 
 ```bash
 docsfy --help
 ```
 
-If not found: `uv tool install docsfy`
+- If found: use `docsfy` as the command throughout this workflow.
+- If NOT found: use `uvx docsfy` instead — this runs docsfy on-the-fly via uv without requiring installation. Verify `uvx` is available (`uvx --help`). If neither `docsfy` nor `uvx` is available, inform the user they need to install either docsfy (`uv tool install docsfy`) or uv (which provides `uvx`).
+
+**For the rest of this document, `docsfy` refers to whichever command is available (`docsfy` or `uvx docsfy`).** All example commands show `docsfy` — substitute `uvx docsfy` if that's what's being used.
 
 ### 2. Server is alive
 
@@ -26,7 +31,7 @@ docsfy health
 ```
 
 If health check fails, inform the user that the docsfy server is not reachable and stop. The user may need to:
-- Start the server: `docsfy-server`
+- Start the server: `docsfy-server` (or `uvx --from docsfy docsfy-server` if not installed — note: `docsfy-server` is a separate entry point in the same package; bare `uvx docsfy-server` will not work)
 - Check their config: `docsfy config show`
 - Set up a profile: `docsfy config init`
 
@@ -105,6 +110,8 @@ Display:
 
 ## Quick Reference
 
+> **Note:** If `docsfy` is not installed, replace `docsfy` with `uvx docsfy` in all commands below.
+
 | Command | Purpose |
 |---------|---------|
 | `docsfy generate <url> --watch` | Generate docs with live progress |
@@ -126,3 +133,4 @@ Display:
 | Forgetting `--watch` flag | Always use `--watch` for real-time progress |
 | Downloading before ready | Check status is `ready` before downloading |
 | Leaving nested download folder | Flatten after download — move files to output root |
+| Requiring docsfy installation in containers | Use `uvx docsfy` when docsfy isn't installed but uv is available |


### PR DESCRIPTION
## Summary

Updates the `docsfy-generate-docs` skill to support running docsfy via `uvx docsfy` when the CLI is not directly installed. This is useful in container environments where `uv` is available but `docsfy` hasn't been installed as a tool.

## Changes

- **Prerequisites**: Renamed "docsfy CLI installed" → "docsfy CLI available" with fallback detection logic (`docsfy` → `uvx docsfy` → error)
- **Substitution note**: All `docsfy` commands in the doc should be substituted with `uvx docsfy` when using the fallback
- **`docsfy-server` handling**: Uses correct `uvx --from docsfy docsfy-server` syntax (bare `uvx docsfy-server` would look for a non-existent package)
- **Quick Reference**: Added note about `uvx docsfy` substitution
- **Common Mistakes**: Added row for container environments

## Peer Review

Reviewed with Cursor (3 rounds). Key finding: `uvx docsfy-server` is incorrect because `uvx` resolves by package name — fixed to `uvx --from docsfy docsfy-server`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated prerequisite instructions to clarify CLI installation requirements and provide `uvx` alternatives for different environments
  * Expanded server startup guidance with fallback commands for scenarios without direct CLI tool access
  * Added quick-reference substitution guide for command examples throughout the documentation
  * Enhanced common mistakes section with specific setup recommendations for container environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->