### PR TITLE
fix: generation pipeline bugs — broken related-pages links, collapsed callouts, unrendered markdown

### DIFF
--- a/src/docsfy/api/projects.py
+++ b/src/docsfy/api/projects.py
@@ -32,9 +32,11 @@ from docsfy.models import (
 )
 from docsfy.postprocess import (
     add_cross_links,
+    convert_details_to_headings,
     detect_version,
     fix_broken_internal_links,
     linkify_plain_references,
+    separate_adjacent_callouts,
     validate_pages,
 )
 from docsfy.renderer import render_site
@@ -1060,6 +1062,11 @@ async def _generate_from_path(
     site_dir = get_project_site_dir(
         project_name, ai_provider, ai_model, owner, branch=branch
     )
+    pages = {
+        slug: convert_details_to_headings(separate_adjacent_callouts(content))
+        for slug, content in pages.items()
+    }
+
     render_site(plan=plan, pages=pages, output_dir=site_dir)
 
     project_dir = get_project_dir(

--- a/src/docsfy/postprocess.py
+++ b/src/docsfy/postprocess.py
@@ -22,8 +22,99 @@ from docsfy.prompts import build_cross_links_prompt, build_validation_prompt
 
 logger = get_logger(name=__name__)
 
-# Regex to identify code fences and inline code that should be skipped
-_CODE_BLOCK_RE = re.compile(r"(```[\s\S]*?```|`[^`\n]+`)")
+
+_CALLOUT_RE = re.compile(r"^>\s*\*\*(Note|Warning|Tip):\*\*", re.IGNORECASE)
+
+_DETAILS_OPEN_RE = re.compile(
+    r"<details[^>]*>\s*<summary[^>]*>(.*?)</summary>",
+    re.IGNORECASE | re.DOTALL,
+)
+_DETAILS_CLOSE_RE = re.compile(
+    r"</details\s*>",
+    re.IGNORECASE,
+)
+
+# Regex to identify code fences (backtick and tilde) and inline code that should be skipped
+_CODE_BLOCK_RE = re.compile(r"(```[\s\S]*?```|~~~[\s\S]*?~~~|`[^`\n]+`)")
+
+
+def separate_adjacent_callouts(md_text: str) -> str:
+    """Separate adjacent blockquote callouts so each renders independently.
+
+    When the AI generates consecutive callouts like:
+        > **Warning:** text
+        > **Note:** text
+    they collapse into a single blockquote. This inserts blank lines
+    between them so each callout is styled independently.
+    """
+    lines = md_text.split("\n")
+    result: list[str] = []
+    in_fence = False
+    opening_fence_len = 0
+    opening_fence_char = "`"
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+
+        # Track fenced code blocks (backtick and tilde fence matching)
+        if stripped.startswith(("```", "~~~")):
+            fence_char = stripped[0]
+            fence_count = len(stripped) - len(stripped.lstrip(fence_char))
+            rest = stripped[fence_count:].strip()
+            if not in_fence:
+                in_fence = True
+                opening_fence_len = fence_count
+                opening_fence_char = fence_char
+            elif (
+                fence_char == opening_fence_char
+                and fence_count >= opening_fence_len
+                and not rest
+            ):
+                in_fence = False
+                opening_fence_len = 0
+
+        if not in_fence and i > 0 and _CALLOUT_RE.match(stripped):
+            # Check if previous non-empty line was also a blockquote
+            prev_idx = i - 1
+            while prev_idx >= 0 and not lines[prev_idx].strip():
+                prev_idx -= 1
+            if prev_idx >= 0 and lines[prev_idx].strip().startswith(">"):
+                # Insert separator between adjacent callouts
+                # Remove any blank lines we just passed over
+                while result and not result[-1].strip():
+                    result.pop()
+                result.append("")
+                result.append("")
+
+        result.append(line)
+
+    return "\n".join(result)
+
+
+def convert_details_to_headings(md_text: str) -> str:
+    """Convert HTML <details><summary> blocks to regular Markdown headings.
+
+    The Python markdown library cannot parse Markdown inside raw HTML blocks,
+    so <details><summary>Title</summary>...</details> renders with literal
+    **bold** markers instead of <strong> tags. Convert these to ## headings.
+
+    Fenced code blocks are skipped to preserve code examples.
+    """
+    parts = _CODE_BLOCK_RE.split(md_text)
+    result: list[str] = []
+    for i, part in enumerate(parts):
+        if i % 2 == 1:
+            # Inside a code fence — preserve as-is
+            result.append(part)
+        else:
+            # Outside code fence — apply transforms
+            part = _DETAILS_OPEN_RE.sub(
+                lambda m: f"\n## {m.group(1).strip()}\n",
+                part,
+            )
+            part = _DETAILS_CLOSE_RE.sub("", part)
+            result.append(part)
+    return "".join(result)
 
 
 def fix_broken_internal_links(

--- a/src/docsfy/prompts.py
+++ b/src/docsfy/prompts.py
@@ -109,6 +109,9 @@ Use these callout formats:
 - Warnings: > **Warning:** text
 - Tips: > **Tip:** text"""
 
+_NO_HTML_DETAILS = """
+- Do NOT use HTML <details> or <summary> tags — the Markdown parser cannot render Markdown inside raw HTML blocks. Use regular headings instead."""
+
 _GUIDE_WRITING_RULES = (
     """Write a task-oriented guide in markdown format. Follow these rules strictly:
 
@@ -119,8 +122,7 @@ STRUCTURE (in this order):
 3. Quick example: Show the simplest working example FIRST, before any explanation.
 4. Step-by-step: Walk through the common use case with clear steps.
 5. Advanced usage: AFTER the basics, cover advanced options, edge cases, or alternatives.
-   Wrap this section in a collapsible block using <details><summary>Advanced Usage</summary>...</details>
-   so it doesn't overwhelm users who only need the basics.
+   Use a regular markdown heading (## Advanced Usage) for this section.
 6. Troubleshooting: Common problems and solutions (only if relevant, keep brief).
 
 CONTENT RULES:
@@ -140,6 +142,7 @@ CONTENT RULES:
 - Prefer bullet lists and numbered steps over long prose.
 - Where architecture, data flow, or component relationships would benefit from a visual, include a Mermaid diagram using a ```mermaid code block. Use flowchart, sequence, or class diagrams as appropriate."""
     + _CALLOUT_FORMATS
+    + _NO_HTML_DETAILS
 )
 
 _REFERENCE_WRITING_RULES = (
@@ -160,6 +163,7 @@ CONTENT RULES:
 - Use code blocks generously.
 - Group related items under clear headings."""
     + _CALLOUT_FORMATS
+    + _NO_HTML_DETAILS
 )
 
 _RECIPE_WRITING_RULES = (
@@ -180,6 +184,7 @@ CONTENT RULES:
 - Practical over theoretical. If it can't be copy-pasted, it's not a recipe.
 - Include real values and realistic examples, not abstract placeholders."""
     + _CALLOUT_FORMATS
+    + _NO_HTML_DETAILS
 )
 
 _CONCEPT_WRITING_RULES = (
@@ -199,6 +204,7 @@ CONTENT RULES:
 - Where architecture, data flow, or component relationships would benefit from a visual, include a Mermaid diagram using a ```mermaid code block.
 - Use clear, approachable language — avoid jargon where possible."""
     + _CALLOUT_FORMATS
+    + _NO_HTML_DETAILS
 )
 
 
@@ -380,7 +386,8 @@ Instructions:
 
 When writing "new_text", follow these content rules:
 {_get_incremental_writing_rules(page_type)}
-{_CALLOUT_FORMATS}"""
+{_CALLOUT_FORMATS}
+{_NO_HTML_DETAILS}"""
 
 
 VALIDATION_SCHEMA = """[

--- a/src/docsfy/renderer.py
+++ b/src/docsfy/renderer.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import contextlib
+import html as _html_mod
 import json
 import re
+import urllib.parse
 import shutil
 import subprocess
 import tempfile
@@ -58,16 +60,30 @@ def _sanitize_html(html: str) -> str:
     # anchor links (#section), relative paths (/page), and mailto: links.
     # All other schemes (javascript:, data:, vbscript:, etc.) are blocked
     # by replacing the URL with "#".
+    def _is_safe_url(url: str) -> bool:
+        """Check if a URL is safe to keep (not a dangerous scheme)."""
+        decoded = _html_mod.unescape(url).strip()
+        decoded_lower = decoded.lower()
+        if decoded_lower.startswith(("http://", "https://", "#", "mailto:")):
+            return True
+        # Allow absolute paths but reject protocol-relative URLs (//evil.com)
+        if decoded.startswith("/") and not decoded.startswith("//"):
+            return True
+        # Reject protocol-relative URLs (//evil.com)
+        if decoded.startswith("//"):
+            return False
+        # Allow relative URLs (no scheme) - e.g., "page-slug.html", "page.html#section:details"
+        # Use urlsplit to check for a scheme — it correctly handles
+        # colons in fragments/paths vs actual schemes
+        parsed = urllib.parse.urlsplit(decoded)
+        return not parsed.scheme  # No scheme = relative URL, safe
+
     def _sanitize_url_attr(match: re.Match) -> str:  # type: ignore[type-arg]
         attr = match.group(1)  # href or src
         quote = match.group(2)  # " or '
         url = match.group(3)  # the URL value
-        # Strip whitespace and decode common HTML entities
-        clean_url = url.strip()
-        # Check for safe schemes
-        if clean_url.startswith(("http://", "https://", "#", "/", "mailto:")):
-            return match.group(0)  # Keep as-is
-        # Block everything else (javascript:, data:, vbscript:, etc.)
+        if _is_safe_url(url):
+            return match.group(0)
         return f"{attr}={quote}#{quote}"
 
     html = re.sub(
@@ -80,8 +96,8 @@ def _sanitize_html(html: str) -> str:
     # Also handle unquoted URLs
     def _sanitize_unquoted_url(match: re.Match) -> str:  # type: ignore[type-arg]
         attr = match.group(1)
-        url = match.group(2).strip()
-        if url.startswith(("http://", "https://", "#", "/", "mailto:")):
+        url = match.group(2)
+        if _is_safe_url(url):
             return match.group(0)
         return f'{attr}="#"'
 


### PR DESCRIPTION
Fixes #55

## Changes

### Bug 1: Related Pages links all `href="#"` (High)
The HTML sanitizer in `renderer.py` blocked relative URLs like `page-slug.html` because they didn't match allowed schemes (`http://`, `https://`, `#`, `/`, `mailto:`). 

**Fix:** Added `_is_safe_url()` helper that allows scheme-less relative URLs while blocking dangerous schemes (`javascript:`, `data:`, protocol-relative `//evil.com`, HTML entity-encoded colons like `javascript&#58;alert(1)`).

### Bug 2: Adjacent blockquote callouts collapse (Medium)
Consecutive `>` callouts (Note/Warning/Tip) merged into a single blockquote, losing severity styling.

**Fix:** Added `separate_adjacent_callouts()` in `postprocess.py` that detects adjacent callouts with different prefixes and inserts blank line separators. Handles both backtick and tilde code fences.

### Bug 3: Markdown inside `<details>` not rendered (Medium)
The Python `markdown` library can't parse Markdown inside raw HTML blocks, so `**bold**` appeared literally.

**Fix:** 
- Updated all AI writing rules to forbid `<details>`/`<summary>` tags (shared `_NO_HTML_DETAILS` constant)
- Added `convert_details_to_headings()` post-processor to convert any remaining `<details>` blocks to `##` headings
- Fence-aware: skips code blocks using `_CODE_BLOCK_RE.split()`

### Wiring
Both post-processors applied in `api/projects.py` before `render_site()`.

## Files Changed
- `src/docsfy/renderer.py` — URL sanitizer fix
- `src/docsfy/postprocess.py` — Two new post-processing functions
- `src/docsfy/prompts.py` — Updated AI writing rules
- `src/docsfy/api/projects.py` — Pipeline wiring

## Testing
- All 376 tests pass
- Reviewed by 3 internal reviewers + Cursor peer review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented adjacent callout blockquotes from collapsing by inserting blank lines between them; this separation is applied during final site rendering.
  * Improved URL sanitization to reject unsafe or protocol‑relative URLs for safer links.

* **New Features**
  * Support for both backtick (```) and tilde (~~~) fenced code blocks when processing content.
  * Automatic conversion of HTML details/summary into Markdown headings.

* **Documentation**
  * Writing prompts updated to forbid HTML details so content uses regular headings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->