### PR TITLE
feat: add unique generation ID (UUID) for each generation job

### DIFF
--- a/frontend/src/components/shared/ProjectTree.tsx
+++ b/frontend/src/components/shared/ProjectTree.tsx
@@ -1,11 +1,12 @@
 import { useState, useMemo, useRef, useEffect } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { ChevronRight, Trash2, GitBranch, ChevronsDown, ChevronsUp } from 'lucide-react'
+import { ChevronRight, Trash2, GitBranch, ChevronsDown, ChevronsUp, Copy } from 'lucide-react'
+import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import StatusDot from './StatusDot'
 import { cn } from '@/lib/utils'
-import { TREE_EXPANDED_KEY } from '@/lib/constants'
+import { TREE_EXPANDED_KEY, TOAST_DEFAULT_MS } from '@/lib/constants'
 import type { Project } from '@/types'
 
 export interface SelectedVariant {
@@ -437,12 +438,19 @@ function VariantRow({
   onSelect: () => void
 }) {
   return (
-    <button
-      type="button"
+    <div
+      role="button"
+      tabIndex={0}
       onClick={onSelect}
+      onKeyDown={(e) => {
+        if ((e.key === 'Enter' || e.key === ' ') && e.target === e.currentTarget) {
+          e.preventDefault()
+          onSelect()
+        }
+      }}
       title={`${project.ai_provider}/${project.ai_model} — ${project.status}${project.page_count ? ` (${project.page_count} pages)` : ''}`}
       className={cn(
-        'flex items-center gap-2 w-full pl-11 pr-2 py-1.5 rounded-md transition-colors text-left',
+        'flex items-center gap-2 w-full pl-11 pr-2 py-1.5 rounded-md transition-colors text-left cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
         isSelected
           ? 'bg-accent text-accent-foreground'
           : 'hover:bg-muted/50 text-foreground'
@@ -452,11 +460,29 @@ function VariantRow({
       <span className="text-sm truncate flex-1 min-w-0">
         {project.ai_provider} / {project.ai_model}
       </span>
+      {project.generation_id && (
+        <button
+          type="button"
+          className="text-[10px] text-muted-foreground font-mono cursor-pointer hover:text-foreground shrink-0 flex items-center gap-0.5 bg-transparent border-none p-0"
+          title={`Click to copy: ${project.generation_id}`}
+          aria-label="Copy generation ID"
+          onClick={(e) => {
+            e.stopPropagation()
+            navigator.clipboard
+              .writeText(project.generation_id!)
+              .then(() => toast.success('Generation ID copied', { duration: TOAST_DEFAULT_MS }))
+              .catch(() => toast.error('Failed to copy'))
+          }}
+        >
+          {project.generation_id.slice(0, 8)}
+          <Copy className="size-2.5" />
+        </button>
+      )}
       {isAdmin && (
         <Badge variant="outline" className="text-[10px] px-1 h-4 shrink-0">
           {project.owner}
         </Badge>
       )}
-    </button>
+    </div>
   )
 }

--- a/frontend/src/components/shared/VariantDetail.tsx
+++ b/frontend/src/components/shared/VariantDetail.tsx
@@ -7,6 +7,7 @@ import {
   AlertTriangle,
   XCircle,
   Square,
+  Copy,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -201,6 +202,28 @@ function InfoGrid({ project, isAdmin }: { project: Project; isAdmin: boolean }) 
         <span className="text-muted-foreground">Last Generated</span>
         <div className="mt-0.5 font-medium">{formatDate(project.last_generated)}</div>
       </div>
+      {project.generation_id && (
+        <div>
+          <span className="text-muted-foreground">Generation ID</span>
+          <div className="mt-0.5 flex items-center gap-1.5">
+            <code className="text-sm font-mono font-medium break-all">{project.generation_id}</code>
+            <button
+              type="button"
+              className="shrink-0 p-0.5 rounded-sm text-muted-foreground hover:text-foreground transition-colors"
+              aria-label="Copy generation ID"
+              onClick={() => {
+                navigator.clipboard
+                  .writeText(project.generation_id!)
+                  .then(() => toast.success('Generation ID copied', { duration: TOAST_DEFAULT_MS }))
+                  .catch(() => toast.error('Failed to copy'))
+              }}
+              title="Copy generation ID"
+            >
+              <Copy className="size-3.5" />
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -210,6 +210,7 @@ export default function DashboardPage() {
                 page_count: message.page_count ?? p.page_count,
                 plan_json: message.plan_json ?? p.plan_json,
                 error_message: message.error_message ?? p.error_message,
+                generation_id: message.generation_id ?? p.generation_id,
               }
             : p
         )
@@ -242,6 +243,7 @@ export default function DashboardPage() {
                 last_generated: message.last_generated ?? p.last_generated,
                 last_commit_sha: message.last_commit_sha ?? p.last_commit_sha,
                 error_message: message.error_message ?? p.error_message,
+                generation_id: message.generation_id ?? p.generation_id,
               }
             : p
         )

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -16,6 +16,7 @@ export interface Project {
   page_count: number
   error_message: string | null
   plan_json: string | null
+  generation_id: string | null
   created_at: string
   updated_at: string
 }
@@ -104,6 +105,7 @@ export interface ProgressMessage {
   page_count?: number
   plan_json?: string | null
   error_message?: string | null
+  generation_id?: string | null
 }
 
 export interface StatusChangeMessage {
@@ -118,6 +120,7 @@ export interface StatusChangeMessage {
   last_generated?: string | null
   last_commit_sha?: string | null
   error_message?: string | null
+  generation_id?: string | null
 }
 
 export class ApiError extends Error {

--- a/src/docsfy/api/projects.py
+++ b/src/docsfy/api/projects.py
@@ -29,6 +29,7 @@ from docsfy.models import (
     DEFAULT_BRANCH,
     VALID_PROVIDERS,
     GenerateRequest,
+    is_uuid,
 )
 from docsfy.postprocess import (
     add_cross_links,
@@ -54,6 +55,7 @@ from docsfy.storage import (
     get_latest_variant,
     get_project,
     get_project_access,
+    get_project_by_generation_id,
     get_project_cache_dir,
     get_project_dir,
     get_project_site_dir,
@@ -116,6 +118,7 @@ async def update_and_notify(
     error_message: str | None = None,
     plan_json: str | None = None,
     current_stage: str | None | object = None,
+    generation_id: str | None = None,
 ) -> None:
     """Update project status in DB and send WebSocket notification."""
     ups_kwargs: dict[str, Any] = {
@@ -150,6 +153,7 @@ async def update_and_notify(
             ),
             last_commit_sha=last_commit_sha,
             error_message=error_message,
+            generation_id=generation_id,
         )
         await notify_sync()
     else:
@@ -160,6 +164,7 @@ async def update_and_notify(
             page_count=page_count,
             plan_json=plan_json,
             error_message=error_message,
+            generation_id=generation_id,
         )
 
 
@@ -536,6 +541,7 @@ async def _run_generation(
     force: bool = False,
     owner: str = "",
     branch: str = DEFAULT_BRANCH,
+    generation_id: str | None = None,
 ) -> None:
     gen_key = f"{owner}/{project_name}/{branch}/{ai_provider}/{ai_model}"
     try:
@@ -553,6 +559,7 @@ async def _run_generation(
                 owner=owner,
                 branch=branch,
                 error_message=msg,
+                generation_id=generation_id,
             )
             return
 
@@ -565,6 +572,7 @@ async def _run_generation(
             owner=owner,
             branch=branch,
             current_stage="cloning",
+            generation_id=generation_id,
         )
 
         if repo_path:
@@ -583,6 +591,7 @@ async def _run_generation(
                 force,
                 owner,
                 branch=branch,
+                generation_id=generation_id,
             )
         else:
             # Remote repository - clone to temp dir
@@ -604,6 +613,7 @@ async def _run_generation(
                     force,
                     owner,
                     branch=branch,
+                    generation_id=generation_id,
                 )
 
     except asyncio.CancelledError:
@@ -618,6 +628,7 @@ async def _run_generation(
             branch=branch,
             error_message="Generation was cancelled",
             current_stage=None,
+            generation_id=generation_id,
         )
         raise
     except Exception as exc:
@@ -631,6 +642,7 @@ async def _run_generation(
             owner=owner,
             branch=branch,
             error_message=str(exc),
+            generation_id=generation_id,
         )
     finally:
         async with _gen_lock:
@@ -648,6 +660,7 @@ async def _generate_from_path(
     force: bool,
     owner: str = "",
     branch: str = DEFAULT_BRANCH,
+    generation_id: str | None = None,
 ) -> None:
     cache_dir = get_project_cache_dir(
         project_name, ai_provider, ai_model, owner, branch=branch
@@ -689,6 +702,7 @@ async def _generate_from_path(
             last_commit_sha=commit_sha,
             page_count=page_count,
             plan_json=plan_json,
+            generation_id=generation_id,
         )
 
     async def _replace_base_variant() -> None:
@@ -719,6 +733,7 @@ async def _generate_from_path(
             owner=owner,
             branch=branch,
             page_count=0,
+            generation_id=generation_id,
         )
     else:
         current_variant = await get_project(
@@ -851,6 +866,7 @@ async def _generate_from_path(
                         branch=branch,
                         current_stage="incremental_planning",
                         page_count=0,
+                        generation_id=generation_id,
                     )
                     pages_to_regen = await run_incremental_planner(
                         repo_dir,
@@ -923,6 +939,7 @@ async def _generate_from_path(
             branch=branch,
             current_stage="planning",
             page_count=0,
+            generation_id=generation_id,
         )
 
         plan = await run_planner(
@@ -959,6 +976,7 @@ async def _generate_from_path(
         current_stage="generating_pages",
         plan_json=json.dumps(plan),
         page_count=current_page_count,
+        generation_id=generation_id,
     )
 
     async def _on_page_generated(page_count: int) -> None:
@@ -967,6 +985,7 @@ async def _generate_from_path(
             status="generating",
             current_stage="generating_pages",
             page_count=page_count,
+            generation_id=generation_id,
         )
 
     pages = await generate_all_pages(
@@ -998,6 +1017,7 @@ async def _generate_from_path(
             branch=branch,
             current_stage="validating",
             page_count=len(pages),
+            generation_id=generation_id,
         )
         pages = await validate_pages(
             pages=pages,
@@ -1023,6 +1043,7 @@ async def _generate_from_path(
             branch=branch,
             current_stage="cross_linking",
             page_count=len(pages),
+            generation_id=generation_id,
         )
         pages = fix_broken_internal_links(pages, plan, project_name=project_name)
         try:
@@ -1057,6 +1078,7 @@ async def _generate_from_path(
         branch=branch,
         current_stage="rendering",
         page_count=len(pages),
+        generation_id=generation_id,
     )
 
     site_dir = get_project_site_dir(
@@ -1087,6 +1109,7 @@ async def _generate_from_path(
         last_commit_sha=commit_sha,
         page_count=page_count,
         plan_json=json.dumps(plan),
+        generation_id=generation_id,
     )
     logger.info(f"[{project_name}] Documentation ready ({page_count} pages)")
 
@@ -1185,6 +1208,27 @@ async def get_models_endpoint() -> dict[str, Any]:
         "default_model": settings.ai_model,
         "known_models": known_models,
     }
+
+
+@router.get("/projects/by-id/{generation_id}")
+async def get_project_by_id(generation_id: str, request: Request) -> dict[str, Any]:
+    """Look up a project variant by its generation UUID."""
+    if not is_uuid(generation_id):
+        raise HTTPException(status_code=400, detail="Invalid generation ID format")
+    project = await get_project_by_generation_id(generation_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Generation ID not found")
+    # Check access
+    if not request.state.is_admin:
+        project_owner = str(project.get("owner", ""))
+        if project_owner != request.state.username:
+            accessible = await get_user_accessible_projects(request.state.username)
+            if (str(project.get("name", "")), project_owner) not in accessible:
+                # Return 404 (not 403) so callers cannot distinguish
+                # "exists but not mine" from "does not exist", matching
+                # _check_ownership / _resolve_project elsewhere in this file.
+                raise HTTPException(status_code=404, detail="Generation ID not found")
+    return project
 
 
 @router.get("/status")
@@ -1291,7 +1335,7 @@ async def generate(
                 detail=f"Variant '{project_name}/{branch}/{ai_provider}/{ai_model}' is already being generated",
             )
 
-        await save_project(
+        gen_id = await save_project(
             name=project_name,
             repo_url=gen_request.repo_url or gen_request.repo_path or "",
             status="generating",
@@ -1314,6 +1358,7 @@ async def generate(
                     force=gen_request.force,
                     owner=owner,
                     branch=branch,
+                    generation_id=gen_id,
                 )
             )
             _generating[gen_key] = task
@@ -1321,7 +1366,12 @@ async def generate(
             _generating.pop(gen_key, None)
             raise
 
-    return {"project": project_name, "status": "generating", "branch": branch}
+    return {
+        "project": project_name,
+        "status": "generating",
+        "branch": branch,
+        "generation_id": gen_id,
+    }
 
 
 @router.get("/projects/{name}/{branch}/{provider}/{model}")

--- a/src/docsfy/api/websocket.py
+++ b/src/docsfy/api/websocket.py
@@ -223,6 +223,7 @@ async def notify_progress(
     page_count: int | None = None,
     plan_json: str | None = None,
     error_message: str | None = None,
+    generation_id: str | None = None,
 ) -> None:
     """Send a progress update for an in-progress generation."""
     # gen_key format: "owner/name/branch/provider/model"
@@ -243,6 +244,8 @@ async def notify_progress(
         "owner": owner,
         "status": status,
     }
+    if generation_id:
+        message["generation_id"] = generation_id
     if current_stage is not None:
         message["current_stage"] = current_stage
     if page_count is not None:
@@ -262,6 +265,7 @@ async def notify_status_change(
     last_generated: str | None = None,
     last_commit_sha: str | None = None,
     error_message: str | None = None,
+    generation_id: str | None = None,
 ) -> None:
     """Send a status change notification (for terminal states)."""
     parts = gen_key.split("/", 4)
@@ -279,6 +283,8 @@ async def notify_status_change(
         "owner": owner,
         "status": status,
     }
+    if generation_id:
+        message["generation_id"] = generation_id
     if page_count is not None:
         message["page_count"] = page_count
     if last_generated is not None:

--- a/src/docsfy/cli/generate.py
+++ b/src/docsfy/cli/generate.py
@@ -166,10 +166,13 @@ def generate(
         project_name = data.get("project", "")
         status = data.get("status", "")
         result_branch = data.get("branch", branch)
+        gen_id = data.get("generation_id", "")
 
         typer.echo(f"Project: {project_name}")
         typer.echo(f"Branch: {result_branch}")
         typer.echo(f"Status: {status}")
+        if gen_id:
+            typer.echo(f"Generation ID: {gen_id}")
 
         if watch and status == "generating":
             srv_url, _, srv_pw = resolve_connection(

--- a/src/docsfy/cli/projects.py
+++ b/src/docsfy/cli/projects.py
@@ -6,9 +6,41 @@ import tempfile
 from pathlib import Path
 from typing import Annotated, Any, Optional
 
+import httpx
 import typer
 
 from docsfy.cli.formatting import print_table
+from docsfy.models import is_uuid
+
+
+def _resolve_generation_id(
+    client: httpx.Client,
+    name: str,
+    branch: str | None,
+    provider: str | None,
+    model: str | None,
+) -> tuple[str, str | None, str | None, str | None, str | None]:
+    """If name is a UUID, resolve it to (name, branch, provider, model, owner) via API. Otherwise return as-is."""
+    if not is_uuid(name):
+        return name, branch, provider, model, None
+    response = client.get(f"/api/projects/by-id/{name}")
+    if response.status_code == 404:
+        typer.echo(f"Generation ID not found: {name}", err=True)
+        raise typer.Exit(1)
+    if not response.is_success:
+        typer.echo(
+            f"Failed to resolve generation ID: HTTP {response.status_code}",
+            err=True,
+        )
+        raise typer.Exit(1)
+    data = response.json()
+    return (
+        data["name"],
+        branch or data["branch"],
+        provider or data["ai_provider"],
+        model or data["ai_model"],
+        data.get("owner"),
+    )
 
 
 def list_projects(
@@ -53,11 +85,21 @@ def list_projects(
                     str(p.get("status", "")),
                     str(p.get("owner", "")),
                     str(p.get("page_count", "") or ""),
+                    str(p.get("generation_id", "") or ""),
                 ]
             )
 
         print_table(
-            ["NAME", "BRANCH", "PROVIDER", "MODEL", "STATUS", "OWNER", "PAGES"],
+            [
+                "NAME",
+                "BRANCH",
+                "PROVIDER",
+                "MODEL",
+                "STATUS",
+                "OWNER",
+                "PAGES",
+                "GEN ID",
+            ],
             rows,
         )
     finally:
@@ -65,7 +107,7 @@ def list_projects(
 
 
 def status(
-    name: str = typer.Argument(help="Project name"),  # noqa: M511
+    name: str = typer.Argument(help="Project name or generation ID (UUID)"),  # noqa: M511
     branch: Optional[str] = typer.Option(  # noqa: M511
         None, "--branch", "-b", help="Filter by branch"
     ),
@@ -83,10 +125,17 @@ def status(
     """Show status of a project and its variants."""
     from docsfy.cli.main import get_client
 
-    owner_qs = f"?owner={owner}" if owner else ""
-
     client = get_client()
     try:
+        # Resolve UUID if name looks like one
+        name, branch, provider, model, resolved_owner = _resolve_generation_id(
+            client, name, branch, provider, model
+        )
+        if resolved_owner and not owner:
+            owner = resolved_owner
+
+        owner_qs = f"?owner={owner}" if owner else ""
+
         # If all three are specified, get the specific variant
         if branch and provider and model:
             response = client.get(
@@ -136,6 +185,8 @@ def _print_variant_detail(v: dict[str, Any]) -> None:
     typer.echo(
         f"  {v.get('branch', 'main')}/{v.get('ai_provider', '')}/{v.get('ai_model', '')}"
     )
+    if v.get("generation_id"):
+        typer.echo(f"    ID:      {v['generation_id']}")
     typer.echo(f"    Status:  {v.get('status', '')}")
     typer.echo(f"    Owner:   {v.get('owner', '')}")
     if v.get("page_count"):
@@ -152,7 +203,7 @@ def _print_variant_detail(v: dict[str, Any]) -> None:
 
 
 def delete(
-    name: str = typer.Argument(help="Project name"),  # noqa: M511
+    name: str = typer.Argument(help="Project name or generation ID (UUID)"),  # noqa: M511
     branch: Optional[str] = typer.Option(  # noqa: M511
         None, "--branch", "-b", help="Branch of variant to delete"
     ),
@@ -175,17 +226,36 @@ def delete(
     """Delete a project or a specific variant."""
     from docsfy.cli.main import get_client
 
-    if all_variants and any([branch, provider, model]):
-        typer.echo(
-            "Use either --all or --branch/--provider/--model, not both.",
-            err=True,
-        )
-        raise typer.Exit(code=1)
-
-    owner_qs = f"?owner={owner}" if owner else ""
-
     client = get_client()
     try:
+        # Resolve UUID if name looks like one
+        original_name = name
+        if all_variants:
+            name, _, _, _, resolved_owner = _resolve_generation_id(
+                client, name, None, None, None
+            )
+            if is_uuid(original_name):
+                typer.echo(
+                    f"Warning: UUID resolved to project '{name}'. "
+                    "--all will delete all variants of this project.",
+                    err=True,
+                )
+        else:
+            name, branch, provider, model, resolved_owner = _resolve_generation_id(
+                client, name, branch, provider, model
+            )
+        if resolved_owner and not owner:
+            owner = resolved_owner
+
+        if all_variants and any([branch, provider, model]):
+            typer.echo(
+                "Use either --all or --branch/--provider/--model, not both.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
+        owner_qs = f"?owner={owner}" if owner else ""
+
         if all_variants:
             if not yes:
                 confirmed = typer.confirm(f"Delete ALL variants of '{name}'?")
@@ -217,7 +287,7 @@ def delete(
 
 
 def abort(
-    name: str = typer.Argument(help="Project name"),  # noqa: M511
+    name: str = typer.Argument(help="Project name or generation ID (UUID)"),  # noqa: M511
     branch: Optional[str] = typer.Option(  # noqa: M511
         None, "--branch", "-b", help="Branch of variant to abort"
     ),
@@ -234,20 +304,27 @@ def abort(
     """Abort an active documentation generation."""
     from docsfy.cli.main import get_client
 
-    # Require all variant selectors together, or none
-    variant_opts = [branch, provider, model]
-    if any(variant_opts) and not all(variant_opts):
-        typer.echo(
-            "Specify --branch, --provider, and --model together to abort a specific variant, "
-            "or omit all three to abort by project name.",
-            err=True,
-        )
-        raise typer.Exit(code=1)
-
-    owner_qs = f"?owner={owner}" if owner else ""
-
     client = get_client()
     try:
+        # Resolve UUID if name looks like one
+        name, branch, provider, model, resolved_owner = _resolve_generation_id(
+            client, name, branch, provider, model
+        )
+        if resolved_owner and not owner:
+            owner = resolved_owner
+
+        # Require all variant selectors together, or none
+        variant_opts = [branch, provider, model]
+        if any(variant_opts) and not all(variant_opts):
+            typer.echo(
+                "Specify --branch, --provider, and --model together to abort a specific variant, "
+                "or omit all three to abort by project name.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
+        owner_qs = f"?owner={owner}" if owner else ""
+
         if branch and provider and model:
             client.post(
                 f"/api/projects/{name}/{branch}/{provider}/{model}/abort{owner_qs}"
@@ -261,7 +338,7 @@ def abort(
 
 
 def download(
-    name: str = typer.Argument(help="Project name"),  # noqa: M511
+    name: str = typer.Argument(help="Project name or generation ID (UUID)"),  # noqa: M511
     branch: Optional[str] = typer.Option(  # noqa: M511
         None, "--branch", "-b", help="Branch of variant to download"
     ),
@@ -284,20 +361,27 @@ def download(
     """Download generated documentation as tar.gz or extract to a directory."""
     from docsfy.cli.main import get_client
 
-    # Require all variant selectors together, or none
-    variant_opts = [branch, provider, model]
-    if any(variant_opts) and not all(variant_opts):
-        typer.echo(
-            "Specify --branch, --provider, and --model together to download a specific variant, "
-            "or omit all three to download the default variant.",
-            err=True,
-        )
-        raise typer.Exit(code=1)
-
-    owner_qs = f"?owner={owner}" if owner else ""
-
     client = get_client()
     try:
+        # Resolve UUID if name looks like one
+        name, branch, provider, model, resolved_owner = _resolve_generation_id(
+            client, name, branch, provider, model
+        )
+        if resolved_owner and not owner:
+            owner = resolved_owner
+
+        # Require all variant selectors together, or none
+        variant_opts = [branch, provider, model]
+        if any(variant_opts) and not all(variant_opts):
+            typer.echo(
+                "Specify --branch, --provider, and --model together to download a specific variant, "
+                "or omit all three to download the default variant.",
+                err=True,
+            )
+            raise typer.Exit(code=1)
+
+        owner_qs = f"?owner={owner}" if owner else ""
+
         if branch and provider and model:
             url_path = (
                 f"/api/projects/{name}/{branch}/{provider}/{model}/download{owner_qs}"

--- a/src/docsfy/models.py
+++ b/src/docsfy/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import uuid as _uuid_mod
 from pathlib import Path
 from typing import Any, Literal, get_args
 
@@ -116,3 +117,13 @@ class DocPlan(BaseModel):
     tagline: str = ""
     navigation: list[NavGroup] = Field(default_factory=list)
     version: str | None = None
+
+
+def is_uuid(value: str) -> bool:
+    """Check if a string is a canonical hyphenated UUID (8-4-4-4-12)."""
+    try:
+        parsed = _uuid_mod.UUID(value)
+    except (ValueError, TypeError, AttributeError):
+        return False
+    # Reject non-canonical forms (urn:uuid:, braces, 32-char hex, etc.)
+    return str(parsed) == value.lower()

--- a/src/docsfy/storage.py
+++ b/src/docsfy/storage.py
@@ -8,8 +8,10 @@ import re
 import secrets
 import shutil
 import sqlite3
+import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from typing import Any
 
 import aiosqlite
 from simple_logger.logger import get_logger
@@ -66,6 +68,7 @@ async def init_db(data_dir: str = "") -> None:
                 ai_provider TEXT NOT NULL DEFAULT '',
                 ai_model TEXT NOT NULL DEFAULT '',
                 owner TEXT NOT NULL DEFAULT '',
+                generation_id TEXT,
                 repo_url TEXT NOT NULL,
                 status TEXT NOT NULL DEFAULT 'generating',
                 current_stage TEXT,
@@ -135,6 +138,7 @@ async def init_db(data_dir: str = "") -> None:
                     ai_provider TEXT NOT NULL DEFAULT '',
                     ai_model TEXT NOT NULL DEFAULT '',
                     owner TEXT NOT NULL DEFAULT '',
+                    generation_id TEXT,
                     repo_url TEXT NOT NULL,
                     status TEXT NOT NULL DEFAULT 'generating',
                     current_stage TEXT,
@@ -172,6 +176,11 @@ async def init_db(data_dir: str = "") -> None:
                 if "owner" in old_columns
                 else "'' AS owner"
             )
+            select_cols.append(
+                "generation_id"
+                if "generation_id" in old_columns
+                else "NULL AS generation_id"
+            )
             select_cols.append("repo_url")
             select_cols.append("status")
             select_cols.append(
@@ -189,7 +198,7 @@ async def init_db(data_dir: str = "") -> None:
 
             await db.execute(f"""
                 INSERT OR IGNORE INTO projects_new
-                    (name, branch, ai_provider, ai_model, owner, repo_url, status, current_stage,
+                    (name, branch, ai_provider, ai_model, owner, generation_id, repo_url, status, current_stage,
                      last_commit_sha, last_generated, page_count, error_message,
                      plan_json, created_at, updated_at)
                 SELECT {", ".join(select_cols)}
@@ -198,6 +207,33 @@ async def init_db(data_dir: str = "") -> None:
             await db.execute("DROP TABLE projects")
             await db.execute("ALTER TABLE projects_new RENAME TO projects")
             logger.info("Database migration to 5-column PK complete")
+
+        # Migration: add generation_id column
+        try:
+            await db.execute("ALTER TABLE projects ADD COLUMN generation_id TEXT")
+            await db.commit()
+        except sqlite3.OperationalError as exc:
+            if "duplicate column name" not in str(exc).lower():
+                logger.exception("Migration failed while adding generation_id column")
+                raise
+
+        # Backfill generation_id for existing rows
+        async with db.execute(
+            "SELECT name, branch, ai_provider, ai_model, owner FROM projects WHERE generation_id IS NULL"
+        ) as cursor:
+            rows = await cursor.fetchall()
+        if rows:
+            await db.executemany(
+                "UPDATE projects SET generation_id = ? WHERE name = ? AND branch = ? AND ai_provider = ? AND ai_model = ? AND owner = ?",
+                [(str(uuid.uuid4()), r[0], r[1], r[2], r[3], r[4]) for r in rows],
+            )
+            await db.commit()
+
+        # Index on generation_id
+        await db.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_projects_generation_id ON projects(generation_id)"
+        )
+        await db.commit()
 
         # Reset orphaned "generating" projects from previous server run
         cursor = await db.execute(
@@ -294,23 +330,50 @@ async def save_project(
     ai_model: str = "",
     owner: str = "",
     branch: str = DEFAULT_BRANCH,
-) -> None:
+    generation_id: str | None = None,
+) -> str:
+    """Save or update a project variant. Returns the generation_id."""
     if status not in VALID_STATUSES:
         msg = f"Invalid project status: '{status}'. Valid: {', '.join(sorted(VALID_STATUSES))}"
         raise ValueError(msg)
     async with aiosqlite.connect(DB_PATH) as db:
+        # ON CONFLICT ... DO UPDATE uses COALESCE(projects.generation_id, excluded.generation_id)
+        # to preserve the existing row's generation_id when it is already set.
+        final_gen_id = generation_id or str(uuid.uuid4())
+
         await db.execute(
-            """INSERT INTO projects (name, branch, ai_provider, ai_model, owner, repo_url, status, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            """INSERT INTO projects (name, branch, ai_provider, ai_model, owner, generation_id, repo_url, status, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
                ON CONFLICT(name, branch, ai_provider, ai_model, owner) DO UPDATE SET
                repo_url = excluded.repo_url,
                status = excluded.status,
+               generation_id = COALESCE(projects.generation_id, excluded.generation_id),
                error_message = NULL,
                current_stage = NULL,
                updated_at = CURRENT_TIMESTAMP""",
-            (name, branch, ai_provider, ai_model, owner, repo_url, status),
+            (
+                name,
+                branch,
+                ai_provider,
+                ai_model,
+                owner,
+                final_gen_id,
+                repo_url,
+                status,
+            ),
         )
         await db.commit()
+
+        # Re-read the actual persisted generation_id to handle race conditions
+        # where COALESCE preserved an existing value instead of our generated one
+        async with db.execute(
+            "SELECT generation_id FROM projects WHERE name = ? AND branch = ? AND ai_provider = ? AND ai_model = ? AND owner = ?",
+            (name, branch, ai_provider, ai_model, owner),
+        ) as cursor:
+            row = await cursor.fetchone()
+            if row and row[0]:
+                return str(row[0])
+    return final_gen_id
 
 
 async def update_project_status(
@@ -383,6 +446,18 @@ async def get_project(
         cursor = await db.execute(query, params)
         row = await cursor.fetchone()
         return dict(row) if row else None
+
+
+async def get_project_by_generation_id(generation_id: str) -> dict[str, Any] | None:
+    """Look up a project variant by its generation_id UUID."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT * FROM projects WHERE generation_id = ?",
+            (generation_id,),
+        ) as cursor:
+            row = await cursor.fetchone()
+            return dict(row) if row else None
 
 
 async def list_projects(


### PR DESCRIPTION
Fixes #57

## Summary

Adds a UUID generation ID to each project variant so users can reference generations with a single short ID instead of the 5-field composite key (name/branch/provider/model/owner).

## Changes

### Backend
- **Database**: Added `generation_id` column to projects table with migration, backfill, and unique index
- **Storage**: `save_project()` returns generation_id, preserves existing ID on re-generation
- **API**: New `GET /projects/by-id/{generation_id}` endpoint with UUID validation and access control
- **Generate**: Returns `generation_id` in response
- **WebSocket**: `generation_id` included in progress and status_change messages (threaded through pipeline, no extra DB queries)
- **Models**: Added shared `is_uuid()` validator

### CLI
- `docsfy generate` displays the Generation ID after starting
- `docsfy status/abort/delete/download` accept a UUID as the name argument — auto-resolves to the full variant
- `docsfy list` shows GEN ID column

### Frontend
- Project type updated with `generation_id` field
- ProjectTree: truncated UUID (8 chars) with copy-to-clipboard
- VariantDetail: full UUID with copy button and toast feedback
- WebSocket handlers propagate generation_id

## Testing
- All 376 tests pass
- Frontend builds successfully
- Reviewed by 3 internal reviewers (2 rounds)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generation ID shown in UI (variant rows, detail view) with copy-to-clipboard and toast feedback
  * Generation ID delivered in generation responses and realtime updates; new API to fetch a project by generation ID
  * CLI: accept/resolves generation IDs, show GEN ID in listings/details, and print Generation ID on generate

* **Chores**
  * Persisted generation IDs, backfilled existing projects, added UUID validation and index
<!-- end of auto-generated comment: release notes by coderabbit.ai -->