### PR TITLE
feat: use ai-cli-runner model discovery and cost tracking

### DIFF
--- a/docs/http-api-and-websocket-reference.html
+++ b/docs/http-api-and-websocket-reference.html
@@ -357,6 +357,11 @@
 <td>Stringified JSON plan. This field is not parsed for you.</td>
 </tr>
 <tr>
+<td><code>total_cost_usd</code></td>
+<td>number or <code>null</code></td>
+<td>Cost of the most recent generation for this variant in USD. Resets on each regeneration. <code>null</code> when not yet tracked.</td>
+</tr>
+<tr>
 <td><code>generation_id</code></td>
 <td>string or <code>null</code></td>
 <td>Hyphenated UUID that identifies the variant.</td>
@@ -472,6 +477,7 @@
 <span class="w">  </span><span class="nt">&quot;error_message&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span>
 <span class="w">  </span><span class="nt">&quot;plan_json&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;{\&quot;project_name\&quot;:\&quot;for-testing-only\&quot;,\&quot;tagline\&quot;:\&quot;Test repo\&quot;,\&quot;navigation\&quot;:[]}&quot;</span><span class="p">,</span>
 <span class="w">  </span><span class="nt">&quot;generation_id&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;5bf1495b-b6fa-4318-841c-dced628a2c5b&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;total_cost_usd&quot;</span><span class="p">:</span><span class="w"> </span><span class="mf">1.4628</span><span class="p">,</span>
 <span class="w">  </span><span class="nt">&quot;created_at&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;2026-04-18 12:00:00&quot;</span><span class="p">,</span>
 <span class="w">  </span><span class="nt">&quot;updated_at&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;2026-04-18 12:34:56&quot;</span>
 <span class="p">}</span>
@@ -495,9 +501,14 @@
 <td>Visible variants for the caller, including non-ready variants.</td>
 </tr>
 <tr>
-<td><code>known_models</code></td>
+<td><code>available_models</code></td>
 <td>object</td>
-<td>Ready models grouped by provider. This list is global, not access-filtered.</td>
+<td>Available models grouped by provider. Each value is an array of <code>{id, name}</code> objects discovered from AI CLI tools and LiteLLM pricing data.</td>
+</tr>
+<tr>
+<td><code>total_cost_usd</code></td>
+<td>number</td>
+<td>Sum of per-variant generation costs in USD. Admins see all variants; non-admin users see only their own.</td>
 </tr>
 <tr>
 <td><code>known_branches</code></td>
@@ -523,14 +534,16 @@
 <span class="w">      </span><span class="nt">&quot;error_message&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span>
 <span class="w">      </span><span class="nt">&quot;plan_json&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span>
 <span class="w">      </span><span class="nt">&quot;generation_id&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;5bf1495b-b6fa-4318-841c-dced628a2c5b&quot;</span><span class="p">,</span>
+<span class="w">      </span><span class="nt">&quot;total_cost_usd&quot;</span><span class="p">:</span><span class="w"> </span><span class="mf">1.4628</span><span class="p">,</span>
 <span class="w">      </span><span class="nt">&quot;created_at&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;2026-04-18 12:00:00&quot;</span><span class="p">,</span>
 <span class="w">      </span><span class="nt">&quot;updated_at&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;2026-04-18 12:34:56&quot;</span>
 <span class="w">    </span><span class="p">}</span>
 <span class="w">  </span><span class="p">],</span>
-<span class="w">  </span><span class="nt">&quot;known_models&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">{</span>
-<span class="w">    </span><span class="nt">&quot;claude&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">&quot;opus&quot;</span><span class="p">],</span>
-<span class="w">    </span><span class="nt">&quot;cursor&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">&quot;gpt-5.4-xhigh-fast&quot;</span><span class="p">]</span>
+<span class="w">  </span><span class="nt">&quot;available_models&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">{</span>
+<span class="w">    </span><span class="nt">&quot;claude&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[{</span><span class="nt">&quot;id&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;opus&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Claude Opus&quot;</span><span class="p">}],</span>
+<span class="w">    </span><span class="nt">&quot;cursor&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[{</span><span class="nt">&quot;id&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;gpt-5.4-xhigh-fast&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;GPT-5.4 XHigh Fast&quot;</span><span class="p">}]</span>
 <span class="w">  </span><span class="p">},</span>
+<span class="w">  </span><span class="nt">&quot;total_cost_usd&quot;</span><span class="p">:</span><span class="w"> </span><span class="mf">1.23</span><span class="p">,</span>
 <span class="w">  </span><span class="nt">&quot;known_branches&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">{</span>
 <span class="w">    </span><span class="nt">&quot;for-testing-only&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">&quot;main&quot;</span><span class="p">,</span><span class="w"> </span><span class="s2">&quot;dev&quot;</span><span class="p">]</span>
 <span class="w">  </span><span class="p">}</span>
@@ -569,7 +582,7 @@
 
 <p>Returns <code>200 OK</code> when the service is up.</p>
 <h3 id="get-apimodels"><code>GET /api/models</code></h3>
-<p>Public discovery endpoint for supported providers, server defaults, and known ready models.</p>
+<p>Public discovery endpoint for supported providers, server defaults, and discovered models from provider APIs.</p>
 <p>Auth: <code>Public</code></p>
 <p>No parameters.</p>
 <p>Response body:</p>
@@ -598,9 +611,9 @@
 <td>Server default model used when <code>POST /api/generate</code> omits <code>ai_model</code>.</td>
 </tr>
 <tr>
-<td><code>known_models</code></td>
+<td><code>available_models</code></td>
 <td>object</td>
-<td>Ready models grouped by provider.</td>
+<td>Available models grouped by provider. Each value is an array of <code>{id, name}</code> objects.</td>
 </tr>
 </tbody>
 </table>
@@ -611,14 +624,43 @@
 <span class="w">  </span><span class="nt">&quot;providers&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">&quot;claude&quot;</span><span class="p">,</span><span class="w"> </span><span class="s2">&quot;gemini&quot;</span><span class="p">,</span><span class="w"> </span><span class="s2">&quot;cursor&quot;</span><span class="p">],</span>
 <span class="w">  </span><span class="nt">&quot;default_provider&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;cursor&quot;</span><span class="p">,</span>
 <span class="w">  </span><span class="nt">&quot;default_model&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;gpt-5.4-xhigh-fast&quot;</span><span class="p">,</span>
-<span class="w">  </span><span class="nt">&quot;known_models&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">{</span>
-<span class="w">    </span><span class="nt">&quot;claude&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">&quot;opus&quot;</span><span class="p">],</span>
-<span class="w">    </span><span class="nt">&quot;gemini&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">&quot;pro&quot;</span><span class="p">]</span>
+<span class="w">  </span><span class="nt">&quot;available_models&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">{</span>
+<span class="w">    </span><span class="nt">&quot;claude&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[{</span><span class="nt">&quot;id&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;opus&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Claude Opus&quot;</span><span class="p">}],</span>
+<span class="w">    </span><span class="nt">&quot;gemini&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[{</span><span class="nt">&quot;id&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;pro&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Gemini Pro&quot;</span><span class="p">}]</span>
 <span class="w">  </span><span class="p">}</span>
 <span class="p">}</span>
 </code></pre></div>
 
-<p>Returns <code>200 OK</code>. <code>known_models</code> is derived from ready variants only.</p>
+<p>Returns <code>200 OK</code>. <code>available_models</code> is discovered from AI CLI tools and LiteLLM pricing data.</p>
+<h3 id="get-apicost"><code>GET /api/cost</code></h3>
+<p>Return the total accumulated cost across all generations.</p>
+<p>Auth: <code>Bearer token or session cookie</code></p>
+<p>No parameters.</p>
+<p>Response body:</p>
+<table>
+<thead>
+<tr>
+<th>Name</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>total_cost_usd</code></td>
+<td>number</td>
+<td>Sum of per-variant generation costs in USD. Admins see all variants; non-admin users see only their own.</td>
+</tr>
+</tbody>
+</table>
+<div class="highlight"><pre><span></span><code>curl<span class="w"> </span>-H<span class="w"> </span><span class="s2">&quot;Authorization: Bearer &lt;USER_API_KEY&gt;&quot;</span><span class="w"> </span><span class="se">\</span>
+<span class="w">  </span>http://localhost:8000/api/cost
+</code></pre></div>
+
+<div class="highlight"><pre><span></span><code><span class="p">{</span><span class="nt">&quot;total_cost_usd&quot;</span><span class="p">:</span><span class="w"> </span><span class="mf">4.56</span><span class="p">}</span>
+</code></pre></div>
+
+<p>Returns <code>200 OK</code>.</p>
 <h2 id="authentication-endpoints">Authentication endpoints</h2>
 <h3 id="post-apiauthlogin"><code>POST /api/auth/login</code></h3>
 <p>Create a session cookie and return the authenticated identity.</p>
@@ -815,7 +857,7 @@
 <p>Returns <code>200 OK</code>, invalidates all sessions for that user, and clears the caller's <code>docsfy_session</code>. Returns <code>400</code> for malformed JSON, non-object JSON, short custom keys, or when the caller is the bootstrap <code>ADMIN_KEY</code> identity.</p>
 <h2 id="project-listing-and-lookup">Project listing and lookup</h2>
 <h3 id="get-apiprojects-and-get-apistatus"><code>GET /api/projects</code> and <code>GET /api/status</code></h3>
-<p>List visible project variants and the known ready models and branches.</p>
+<p>List visible project variants and the discovered models from provider APIs and branches.</p>
 <p>Auth: <code>Bearer token or session cookie</code></p>
 <p>No parameters.</p>
 <div class="highlight"><pre><span></span><code>curl<span class="w"> </span>-H<span class="w"> </span><span class="s2">&quot;Authorization: Bearer &lt;USER_API_KEY&gt;&quot;</span><span class="w"> </span><span class="se">\</span>
@@ -839,13 +881,15 @@
 <span class="w">      </span><span class="nt">&quot;error_message&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span>
 <span class="w">      </span><span class="nt">&quot;plan_json&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span>
 <span class="w">      </span><span class="nt">&quot;generation_id&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;5bf1495b-b6fa-4318-841c-dced628a2c5b&quot;</span><span class="p">,</span>
+<span class="w">      </span><span class="nt">&quot;total_cost_usd&quot;</span><span class="p">:</span><span class="w"> </span><span class="mf">1.4628</span><span class="p">,</span>
 <span class="w">      </span><span class="nt">&quot;created_at&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;2026-04-18 12:00:00&quot;</span><span class="p">,</span>
 <span class="w">      </span><span class="nt">&quot;updated_at&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;2026-04-18 12:34:56&quot;</span>
 <span class="w">    </span><span class="p">}</span>
 <span class="w">  </span><span class="p">],</span>
-<span class="w">  </span><span class="nt">&quot;known_models&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">{</span>
-<span class="w">    </span><span class="nt">&quot;claude&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">&quot;opus&quot;</span><span class="p">]</span>
+<span class="w">  </span><span class="nt">&quot;available_models&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">{</span>
+<span class="w">    </span><span class="nt">&quot;claude&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[{</span><span class="nt">&quot;id&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;opus&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Claude Opus&quot;</span><span class="p">}]</span>
 <span class="w">  </span><span class="p">},</span>
+<span class="w">  </span><span class="nt">&quot;total_cost_usd&quot;</span><span class="p">:</span><span class="w"> </span><span class="mf">1.23</span><span class="p">,</span>
 <span class="w">  </span><span class="nt">&quot;known_branches&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">{</span>
 <span class="w">    </span><span class="nt">&quot;for-testing-only&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">&quot;main&quot;</span><span class="p">,</span><span class="w"> </span><span class="s2">&quot;dev&quot;</span><span class="p">]</span>
 <span class="w">  </span><span class="p">}</span>
@@ -894,6 +938,7 @@
 <span class="w">  </span><span class="nt">&quot;error_message&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span>
 <span class="w">  </span><span class="nt">&quot;plan_json&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span>
 <span class="w">  </span><span class="nt">&quot;generation_id&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;5bf1495b-b6fa-4318-841c-dced628a2c5b&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;total_cost_usd&quot;</span><span class="p">:</span><span class="w"> </span><span class="mf">1.4628</span><span class="p">,</span>
 <span class="w">  </span><span class="nt">&quot;created_at&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;2026-04-18 12:00:00&quot;</span><span class="p">,</span>
 <span class="w">  </span><span class="nt">&quot;updated_at&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;2026-04-18 12:34:56&quot;</span>
 <span class="p">}</span>
@@ -944,6 +989,7 @@
 <span class="w">      </span><span class="nt">&quot;error_message&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span>
 <span class="w">      </span><span class="nt">&quot;plan_json&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span>
 <span class="w">      </span><span class="nt">&quot;generation_id&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;5bf1495b-b6fa-4318-841c-dced628a2c5b&quot;</span><span class="p">,</span>
+<span class="w">      </span><span class="nt">&quot;total_cost_usd&quot;</span><span class="p">:</span><span class="w"> </span><span class="mf">1.4628</span><span class="p">,</span>
 <span class="w">      </span><span class="nt">&quot;created_at&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;2026-04-18 12:00:00&quot;</span><span class="p">,</span>
 <span class="w">      </span><span class="nt">&quot;updated_at&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;2026-04-18 12:34:56&quot;</span>
 <span class="w">    </span><span class="p">}</span>
@@ -1030,6 +1076,7 @@
 <span class="w">  </span><span class="nt">&quot;error_message&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span>
 <span class="w">  </span><span class="nt">&quot;plan_json&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span>
 <span class="w">  </span><span class="nt">&quot;generation_id&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;5bf1495b-b6fa-4318-841c-dced628a2c5b&quot;</span><span class="p">,</span>
+<span class="w">  </span><span class="nt">&quot;total_cost_usd&quot;</span><span class="p">:</span><span class="w"> </span><span class="mf">1.4628</span><span class="p">,</span>
 <span class="w">  </span><span class="nt">&quot;created_at&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;2026-04-18 12:00:00&quot;</span><span class="p">,</span>
 <span class="w">  </span><span class="nt">&quot;updated_at&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;2026-04-18 12:34:56&quot;</span>
 <span class="p">}</span>
@@ -2198,8 +2245,13 @@
 <td>Full visible project snapshot.</td>
 </tr>
 <tr>
-<td><code>known_models</code></td>
+<td><code>available_models</code></td>
 <td>object</td>
+<td>Same structure as <code>GET /api/projects</code>.</td>
+</tr>
+<tr>
+<td><code>total_cost_usd</code></td>
+<td>number</td>
 <td>Same structure as <code>GET /api/projects</code>.</td>
 </tr>
 <tr>
@@ -2227,13 +2279,15 @@
 <span class="w">      </span><span class="nt">&quot;error_message&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span>
 <span class="w">      </span><span class="nt">&quot;plan_json&quot;</span><span class="p">:</span><span class="w"> </span><span class="kc">null</span><span class="p">,</span>
 <span class="w">      </span><span class="nt">&quot;generation_id&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;5bf1495b-b6fa-4318-841c-dced628a2c5b&quot;</span><span class="p">,</span>
+<span class="w">      </span><span class="nt">&quot;total_cost_usd&quot;</span><span class="p">:</span><span class="w"> </span><span class="mf">1.4628</span><span class="p">,</span>
 <span class="w">      </span><span class="nt">&quot;created_at&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;2026-04-18 12:00:00&quot;</span><span class="p">,</span>
 <span class="w">      </span><span class="nt">&quot;updated_at&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;2026-04-18 12:34:56&quot;</span>
 <span class="w">    </span><span class="p">}</span>
 <span class="w">  </span><span class="p">],</span>
-<span class="w">  </span><span class="nt">&quot;known_models&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">{</span>
-<span class="w">    </span><span class="nt">&quot;claude&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">&quot;opus&quot;</span><span class="p">]</span>
+<span class="w">  </span><span class="nt">&quot;available_models&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">{</span>
+<span class="w">    </span><span class="nt">&quot;claude&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[{</span><span class="nt">&quot;id&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;opus&quot;</span><span class="p">,</span><span class="w"> </span><span class="nt">&quot;name&quot;</span><span class="p">:</span><span class="w"> </span><span class="s2">&quot;Claude Opus&quot;</span><span class="p">}]</span>
 <span class="w">  </span><span class="p">},</span>
+<span class="w">  </span><span class="nt">&quot;total_cost_usd&quot;</span><span class="p">:</span><span class="w"> </span><span class="mf">1.23</span><span class="p">,</span>
 <span class="w">  </span><span class="nt">&quot;known_branches&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">{</span>
 <span class="w">    </span><span class="nt">&quot;for-testing-only&quot;</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="s2">&quot;main&quot;</span><span class="p">,</span><span class="w"> </span><span class="s2">&quot;dev&quot;</span><span class="p">]</span>
 <span class="w">  </span><span class="p">}</span>
@@ -2507,6 +2561,7 @@
 <li><a href="#health-and-discovery">Health and discovery</a><ul>
 <li><a href="#get-health">GET /health</a></li>
 <li><a href="#get-apimodels">GET /api/models</a></li>
+<li><a href="#get-apicost">GET /api/cost</a></li>
 </ul>
 </li>
 <li><a href="#authentication-endpoints">Authentication endpoints</a><ul>

--- a/docs/http-api-and-websocket-reference.md
+++ b/docs/http-api-and-websocket-reference.md
@@ -58,6 +58,7 @@ Used by project listing, project lookup, generation lookup, and WebSocket `sync`
 | `page_count` | integer | Current or final page count. |
 | `error_message` | string or `null` | Terminal error text for `error` or `aborted` variants. |
 | `plan_json` | string or `null` | Stringified JSON plan. This field is not parsed for you. |
+| `total_cost_usd` | number or `null` | Cost of the most recent generation for this variant in USD. Resets on each regeneration. `null` when not yet tracked. |
 | `generation_id` | string or `null` | Hyphenated UUID that identifies the variant. |
 | `created_at` | string | Row creation timestamp in `YYYY-MM-DD HH:MM:SS` format. |
 | `updated_at` | string | Last update timestamp in `YYYY-MM-DD HH:MM:SS` format. |
@@ -101,6 +102,7 @@ Status values:
   "error_message": null,
   "plan_json": "{\"project_name\":\"for-testing-only\",\"tagline\":\"Test repo\",\"navigation\":[]}",
   "generation_id": "5bf1495b-b6fa-4318-841c-dced628a2c5b",
+  "total_cost_usd": 1.4628,
   "created_at": "2026-04-18 12:00:00",
   "updated_at": "2026-04-18 12:34:56"
 }
@@ -115,7 +117,8 @@ Used by `GET /api/projects`, `GET /api/status`, and WebSocket `sync`.
 | Name | Type | Description |
 | --- | --- | --- |
 | `projects` | array of `ProjectVariant` | Visible variants for the caller, including non-ready variants. |
-| `known_models` | object | Ready models grouped by provider. This list is global, not access-filtered. |
+| `available_models` | object | Available models grouped by provider. Each value is an array of `{id, name}` objects discovered from AI CLI tools and LiteLLM pricing data. |
+| `total_cost_usd` | number | Sum of per-variant generation costs in USD. Admins see all variants; non-admin users see only their own. |
 | `known_branches` | object | Ready branches grouped by project name. Admins see all owners; non-admin callers see only their own ready branches. |
 
 ```json
@@ -136,14 +139,16 @@ Used by `GET /api/projects`, `GET /api/status`, and WebSocket `sync`.
       "error_message": null,
       "plan_json": null,
       "generation_id": "5bf1495b-b6fa-4318-841c-dced628a2c5b",
+      "total_cost_usd": 1.4628,
       "created_at": "2026-04-18 12:00:00",
       "updated_at": "2026-04-18 12:34:56"
     }
   ],
-  "known_models": {
-    "claude": ["opus"],
-    "cursor": ["gpt-5.4-xhigh-fast"]
+  "available_models": {
+    "claude": [{"id": "opus", "name": "Claude Opus"}],
+    "cursor": [{"id": "gpt-5.4-xhigh-fast", "name": "GPT-5.4 XHigh Fast"}]
   },
+  "total_cost_usd": 1.23,
   "known_branches": {
     "for-testing-only": ["main", "dev"]
   }
@@ -197,7 +202,7 @@ Returns `200 OK` when the service is up.
 
 ### `GET /api/models`
 
-Public discovery endpoint for supported providers, server defaults, and known ready models.
+Public discovery endpoint for supported providers, server defaults, and discovered models from provider APIs.
 
 Auth: `Public`
 
@@ -210,7 +215,7 @@ Response body:
 | `providers` | array of strings | Supported provider IDs. The current set is `claude`, `gemini`, `cursor`. |
 | `default_provider` | string | Server default provider used when `POST /api/generate` omits `ai_provider`. |
 | `default_model` | string | Server default model used when `POST /api/generate` omits `ai_model`. |
-| `known_models` | object | Ready models grouped by provider. |
+| `available_models` | object | Available models grouped by provider. Each value is an array of `{id, name}` objects. |
 
 ```bash
 curl http://localhost:8000/api/models
@@ -221,14 +226,39 @@ curl http://localhost:8000/api/models
   "providers": ["claude", "gemini", "cursor"],
   "default_provider": "cursor",
   "default_model": "gpt-5.4-xhigh-fast",
-  "known_models": {
-    "claude": ["opus"],
-    "gemini": ["pro"]
+  "available_models": {
+    "claude": [{"id": "opus", "name": "Claude Opus"}],
+    "gemini": [{"id": "pro", "name": "Gemini Pro"}]
   }
 }
 ```
 
-Returns `200 OK`. `known_models` is derived from ready variants only.
+Returns `200 OK`. `available_models` is discovered from AI CLI tools and LiteLLM pricing data.
+
+### `GET /api/cost`
+
+Return the total accumulated cost across all generations.
+
+Auth: `Bearer token or session cookie`
+
+No parameters.
+
+Response body:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `total_cost_usd` | number | Sum of per-variant generation costs in USD. Admins see all variants; non-admin users see only their own. |
+
+```bash
+curl -H "Authorization: Bearer <USER_API_KEY>" \
+  http://localhost:8000/api/cost
+```
+
+```json
+{"total_cost_usd": 4.56}
+```
+
+Returns `200 OK`.
 
 ## Authentication endpoints
 
@@ -364,7 +394,7 @@ Returns `200 OK`, invalidates all sessions for that user, and clears the caller'
 
 ### `GET /api/projects` and `GET /api/status`
 
-List visible project variants and the known ready models and branches.
+List visible project variants and the discovered models from provider APIs and branches.
 
 Auth: `Bearer token or session cookie`
 
@@ -393,13 +423,15 @@ curl -H "Authorization: Bearer <USER_API_KEY>" \
       "error_message": null,
       "plan_json": null,
       "generation_id": "5bf1495b-b6fa-4318-841c-dced628a2c5b",
+      "total_cost_usd": 1.4628,
       "created_at": "2026-04-18 12:00:00",
       "updated_at": "2026-04-18 12:34:56"
     }
   ],
-  "known_models": {
-    "claude": ["opus"]
+  "available_models": {
+    "claude": [{"id": "opus", "name": "Claude Opus"}]
   },
+  "total_cost_usd": 1.23,
   "known_branches": {
     "for-testing-only": ["main", "dev"]
   }
@@ -441,6 +473,7 @@ curl -H "Authorization: Bearer <USER_API_KEY>" \
   "error_message": null,
   "plan_json": null,
   "generation_id": "5bf1495b-b6fa-4318-841c-dced628a2c5b",
+  "total_cost_usd": 1.4628,
   "created_at": "2026-04-18 12:00:00",
   "updated_at": "2026-04-18 12:34:56"
 }
@@ -484,6 +517,7 @@ curl -H "Authorization: Bearer <ADMIN_KEY>" \
       "error_message": null,
       "plan_json": null,
       "generation_id": "5bf1495b-b6fa-4318-841c-dced628a2c5b",
+      "total_cost_usd": 1.4628,
       "created_at": "2026-04-18 12:00:00",
       "updated_at": "2026-04-18 12:34:56"
     }
@@ -535,6 +569,7 @@ curl -H "Authorization: Bearer <ADMIN_KEY>" \
   "error_message": null,
   "plan_json": null,
   "generation_id": "5bf1495b-b6fa-4318-841c-dced628a2c5b",
+  "total_cost_usd": 1.4628,
   "created_at": "2026-04-18 12:00:00",
   "updated_at": "2026-04-18 12:34:56"
 }
@@ -1172,7 +1207,8 @@ Fields:
 | --- | --- | --- |
 | `type` | string | Always `sync`. |
 | `projects` | array of `ProjectVariant` | Full visible project snapshot. |
-| `known_models` | object | Same structure as `GET /api/projects`. |
+| `available_models` | object | Same structure as `GET /api/projects`. |
+| `total_cost_usd` | number | Same structure as `GET /api/projects`. |
 | `known_branches` | object | Same structure as `GET /api/projects`. |
 
 ```json
@@ -1194,13 +1230,15 @@ Fields:
       "error_message": null,
       "plan_json": null,
       "generation_id": "5bf1495b-b6fa-4318-841c-dced628a2c5b",
+      "total_cost_usd": 1.4628,
       "created_at": "2026-04-18 12:00:00",
       "updated_at": "2026-04-18 12:34:56"
     }
   ],
-  "known_models": {
-    "claude": ["opus"]
+  "available_models": {
+    "claude": [{"id": "opus", "name": "Claude Opus"}]
   },
+  "total_cost_usd": 1.23,
   "known_branches": {
     "for-testing-only": ["main", "dev"]
   }

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -132,7 +132,7 @@ flowchart LR
 
 The checked-in defaults are `cursor` and `gpt-5.4-xhigh-fast`. If your docsfy environment is already working with `claude` or `gemini` instead, change those two fields before you click `Generate`.
 
-If the model list is empty, type the model name manually. Suggestions appear only after successful generations have already recorded known models.
+If the model list is empty, type the model name manually. Models are discovered from provider APIs and LiteLLM pricing data.
 
 ### Generate Another Branch
 
@@ -865,7 +865,7 @@ AI_CLI_TIMEOUT=60
 
 These values are the server-side fallback when a run does not supply a provider, a model, or a timeout. After you change them, restart `docsfy-server`. See [Configuration Reference](configuration-reference.html) for the full settings list.
 
-2. Check how defaults and known models appear.
+2. Check how defaults and available models appear.
 
 ```shell
 docsfy models
@@ -875,13 +875,13 @@ docsfy models --provider gemini
 | Surface | What you can choose or see | How defaults appear |
 | --- | --- | --- |
 | Web app `New Generation` | Fixed provider list: `claude`, `gemini`, `cursor`; model suggestions for the selected provider; typed model names | The form does not mark the server default provider or model |
-| `docsfy models` | All supported providers and known models | `(default)` marks the server default provider and model |
+| `docsfy models` | All supported providers and available models | `(default)` marks the server default provider and model |
 | `docsfy generate` | `--provider` and `--model`, or omitted values | Any missing value is filled by the server default |
 
-> **Note:** Known models come from successful `Ready` generations. They are not a live catalog of every model your provider account could use.
+> **Note:** Available models are discovered from provider APIs and LiteLLM pricing data.
 
 
-> **Tip:** On a brand-new server, `docsfy models` can show `(no models used yet)` and the web app model suggestions can be empty. You can still type a model manually.
+> **Tip:** On a brand-new server, `docsfy models` can show `(no models available)` and the web app model suggestions can be empty. You can still type a model manually.
 
 3. Start the run with an explicit pair when you want a predictable result.
 
@@ -931,7 +931,7 @@ Use this table when you want to avoid the most common mismatches:
 
 The web app model field is free-form. If the model you want is not suggested yet, type it exactly and start the run anyway.
 
-After a generation reaches `Ready`, that model becomes part of docsfy’s known-model list for that provider. It then appears in `docsfy models` and in later web app suggestions for that provider.
+Models are discovered from provider APIs. They appear in `docsfy models` and in the web app suggestions for that provider.
 
 The web app remembers the repository URL, branch, and `Force full regeneration` checkbox in the current browser session, but it does not keep your provider or model choice. Each new form starts on `cursor`, so re-check both fields every time if you usually run with `claude` or `gemini`.
 
@@ -946,7 +946,7 @@ See [CLI Command Reference](cli-command-reference.html) for the full command syn
 
 ## Troubleshooting
 
-- `docsfy models` shows `(no models used yet)`: the server can still be healthy. It only means there is no successful `Ready` generation recorded yet for that provider.
+- `docsfy models` shows `(no models available)`: the server can still be healthy. It means provider discovery has not returned models for that provider yet.
 - The web app started on `cursor` again: expected. Provider and model are not remembered between runs.
 - The CLI shows the default pair, but the web app does not: expected. The web app does not mark server defaults.
 - A run used the wrong model: start the next run with both provider and model set explicitly, then verify it with `docsfy status`.
@@ -1403,7 +1403,7 @@ docsfy status for-testing-only --branch main --provider cursor --model gpt-5.4-x
 docsfy download for-testing-only --branch main --provider cursor --model gpt-5.4-xhigh-fast --output ./site
 ```
 
-Use `docsfy models` to see the current default provider and model, plus model names the server already knows about. A provider can show `(no models used yet)` until a ready variant has been generated with it.
+Use `docsfy models` to see the current default provider and model, plus models discovered from provider APIs. A provider can show `(no models available)` if discovery has not returned models for it yet.
 
 Replace `cursor` and `gpt-5.4-xhigh-fast` with the values your server reports. Use `--force` when you want a full rebuild instead of reusing existing artifacts.
 
@@ -1691,11 +1691,11 @@ docsfy models
 docsfy generate https://github.com/myk-org/for-testing-only --branch main --provider cursor --model gpt-5.4-xhigh-fast --force
 ```
 
-Use only `claude`, `gemini`, or `cursor` as provider names. `docsfy models` shows the server defaults and any models docsfy has already seen in ready runs.
+Use only `claude`, `gemini`, or `cursor` as provider names. `docsfy models` shows the server defaults and models discovered from provider APIs.
 
-A provider or model appearing in the UI or in `docsfy models` is not a live health check. Those suggestions come from previous ready variants, so a new generation can still fail immediately if the provider CLI is missing, not signed in, or cannot use that model.
+A provider or model appearing in the UI or in `docsfy models` is not a live health check. Those suggestions come from provider discovery, so a new generation can still fail immediately if the provider CLI is missing, not signed in, or cannot use that model.
 
-On a brand-new server, `docsfy models` can show `(no models used yet)` and still be healthy.
+On a brand-new server, `docsfy models` can show `(no models available)` and still be healthy.
 
 If you run docsfy without Docker, make sure the provider CLI you selected is installed and authenticated on the server machine, then restart the server. See [Install and Run docsfy Without Docker](install-and-run-docsfy-without-docker.html) for the setup steps.
 
@@ -1736,7 +1736,7 @@ Always inspect the exact `branch` / `provider` / `model` combination you are fix
 
 If a run comes back `ready` with an `up_to_date` stage, nothing is broken. docsfy decided the existing docs already match the current repository state.
 
-Where the run stopped helps you narrow the cause. Problems in or before `cloning` usually point to repo or provider setup, while later failures are best diagnosed from the variant’s `Error` field. See [Tracking Generation Progress](track-generation-progress.html) for the fuller stage-by-stage view.
+Where the run stopped helps you narrow the cause. Problems in or before `cloning` usually point to repo or provider setup, while later failures are best diagnosed from the variant's `Error` field. See [Tracking Generation Progress](track-generation-progress.html) for the fuller stage-by-stage view.
 
 ## Advanced Usage
 
@@ -1769,7 +1769,7 @@ Every run gets a generation ID, and the CLI accepts that ID anywhere it normally
 docsfy status for-testing-only --branch main --provider cursor --model gpt-5.4-xhigh-fast --owner <owner>
 ```
 
-Admins can see more than one owner’s copy of the same variant. If you hit a `Multiple owners found` error, rerun the command with `--owner`.
+Admins can see more than one owner's copy of the same variant. If you hit a `Multiple owners found` error, rerun the command with `--owner`.
 
 ### When `--watch` is the only thing failing
 
@@ -1782,7 +1782,7 @@ The CLI `--watch` mode depends on the WebSocket connection. If it times out or d
 
 ### When a branch or model is missing from the web app suggestions
 
-The branch and model fields accept typed values. Their suggestion lists only include branches and models from previous ready variants, so a missing suggestion does not mean the value is invalid.
+The branch and model fields accept typed values. Their model suggestion lists come from provider discovery, and branch suggestions come from previous ready variants, so a missing suggestion does not mean the value is invalid.
 
 ### If you use a local repository path
 
@@ -1903,7 +1903,7 @@ Prints the current config file and all saved profiles.
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| `—` | `—` | `—` | No positional arguments or command-specific options. |
+| `-` | `-` | `-` | No positional arguments or command-specific options. |
 
 ```shell
 $ docsfy config show
@@ -1967,7 +1967,7 @@ Checks whether the configured server responds to `/health`.
 
 | Name | Type | Default | Description |
 | --- | --- | --- | --- |
-| `—` | `—` | `—` | No positional arguments or command-specific options. |
+| `-` | `-` | `-` | No positional arguments or command-specific options. |
 
 ```shell
 $ docsfy health
@@ -2184,7 +2184,7 @@ Provider: claude
   sonnet-4
 
 Provider: gemini
-  (no models used yet)
+  (no models available)
 
 Provider: cursor (default)
   gpt-5.4-xhigh-fast  (default)
@@ -2194,7 +2194,7 @@ Provider: cursor (default)
 - Plain-text output prints one section per provider.
 - The default provider is marked with `(default)`.
 - The default model under the default provider is marked with `  (default)`.
-- Providers with no ready models print `  (no models used yet)`.
+- Providers with no discovered models print `  (no models available)`.
 - `--json` prints the server payload; filtered JSON still includes `default_provider` and `default_model`.
 - Unknown providers print `Unknown provider: <provider>` and exit `1`.
 
@@ -2442,6 +2442,7 @@ Used by project listing, project lookup, generation lookup, and WebSocket `sync`
 | `page_count` | integer | Current or final page count. |
 | `error_message` | string or `null` | Terminal error text for `error` or `aborted` variants. |
 | `plan_json` | string or `null` | Stringified JSON plan. This field is not parsed for you. |
+| `total_cost_usd` | number or `null` | Cost of the most recent generation for this variant in USD. Resets on each regeneration. `null` when not yet tracked. |
 | `generation_id` | string or `null` | Hyphenated UUID that identifies the variant. |
 | `created_at` | string | Row creation timestamp in `YYYY-MM-DD HH:MM:SS` format. |
 | `updated_at` | string | Last update timestamp in `YYYY-MM-DD HH:MM:SS` format. |
@@ -2485,6 +2486,7 @@ Status values:
   "error_message": null,
   "plan_json": "{\"project_name\":\"for-testing-only\",\"tagline\":\"Test repo\",\"navigation\":[]}",
   "generation_id": "5bf1495b-b6fa-4318-841c-dced628a2c5b",
+  "total_cost_usd": 1.4628,
   "created_at": "2026-04-18 12:00:00",
   "updated_at": "2026-04-18 12:34:56"
 }
@@ -2499,7 +2501,8 @@ Used by `GET /api/projects`, `GET /api/status`, and WebSocket `sync`.
 | Name | Type | Description |
 | --- | --- | --- |
 | `projects` | array of `ProjectVariant` | Visible variants for the caller, including non-ready variants. |
-| `known_models` | object | Ready models grouped by provider. This list is global, not access-filtered. |
+| `available_models` | object | Available models grouped by provider. Each value is an array of `{id, name}` objects discovered from AI CLI tools and LiteLLM pricing data. |
+| `total_cost_usd` | number | Sum of per-variant generation costs in USD. Admins see all variants; non-admin users see only their own. |
 | `known_branches` | object | Ready branches grouped by project name. Admins see all owners; non-admin callers see only their own ready branches. |
 
 ```json
@@ -2520,14 +2523,16 @@ Used by `GET /api/projects`, `GET /api/status`, and WebSocket `sync`.
       "error_message": null,
       "plan_json": null,
       "generation_id": "5bf1495b-b6fa-4318-841c-dced628a2c5b",
+      "total_cost_usd": 1.4628,
       "created_at": "2026-04-18 12:00:00",
       "updated_at": "2026-04-18 12:34:56"
     }
   ],
-  "known_models": {
-    "claude": ["opus"],
-    "cursor": ["gpt-5.4-xhigh-fast"]
+  "available_models": {
+    "claude": [{"id": "opus", "name": "Claude Opus"}],
+    "cursor": [{"id": "gpt-5.4-xhigh-fast", "name": "GPT-5.4 XHigh Fast"}]
   },
+  "total_cost_usd": 1.23,
   "known_branches": {
     "for-testing-only": ["main", "dev"]
   }
@@ -2550,7 +2555,7 @@ Most explicit HTTP errors use a `detail` field. Request validation failures use 
     {
       "type": "value_error",
       "loc": ["body", "branch"],
-      "msg": "Value error, Invalid branch name: 'release/1.0'. Branch names cannot contain slashes — use hyphens instead (e.g., release-1.x).",
+      "msg": "Value error, Invalid branch name: 'release/1.0'. Branch names cannot contain slashes - use hyphens instead (e.g., release-1.x).",
       "input": "release/1.0"
     }
   ]
@@ -2581,7 +2586,7 @@ Returns `200 OK` when the service is up.
 
 ### `GET /api/models`
 
-Public discovery endpoint for supported providers, server defaults, and known ready models.
+Public discovery endpoint for supported providers, server defaults, and discovered models.
 
 Auth: `Public`
 
@@ -2594,7 +2599,7 @@ Response body:
 | `providers` | array of strings | Supported provider IDs. The current set is `claude`, `gemini`, `cursor`. |
 | `default_provider` | string | Server default provider used when `POST /api/generate` omits `ai_provider`. |
 | `default_model` | string | Server default model used when `POST /api/generate` omits `ai_model`. |
-| `known_models` | object | Ready models grouped by provider. |
+| `available_models` | object | Available models grouped by provider. Each value is an array of `{id, name}` objects. |
 
 ```bash
 curl http://localhost:8000/api/models
@@ -2605,14 +2610,39 @@ curl http://localhost:8000/api/models
   "providers": ["claude", "gemini", "cursor"],
   "default_provider": "cursor",
   "default_model": "gpt-5.4-xhigh-fast",
-  "known_models": {
-    "claude": ["opus"],
-    "gemini": ["pro"]
+  "available_models": {
+    "claude": [{"id": "opus", "name": "Claude Opus"}],
+    "gemini": [{"id": "pro", "name": "Gemini Pro"}]
   }
 }
 ```
 
-Returns `200 OK`. `known_models` is derived from ready variants only.
+Returns `200 OK`. `available_models` is discovered from AI CLI tools and LiteLLM pricing data.
+
+### `GET /api/cost`
+
+Return the sum of currently stored per-variant costs (resets on regeneration, decreases on deletion).
+
+Auth: `Bearer token or session cookie`
+
+No parameters.
+
+Response body:
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `total_cost_usd` | number | Sum of per-variant generation costs in USD. Admins see all variants; non-admin users see only their own. |
+
+```bash
+curl -H "Authorization: Bearer <USER_API_KEY>" \
+  http://localhost:8000/api/cost
+```
+
+```json
+{"total_cost_usd": 4.56}
+```
+
+Returns `200 OK`.
 
 ## Authentication endpoints
 
@@ -2748,7 +2778,7 @@ Returns `200 OK`, invalidates all sessions for that user, and clears the caller'
 
 ### `GET /api/projects` and `GET /api/status`
 
-List visible project variants and the known ready models and branches.
+List visible project variants and the discovered models and branches.
 
 Auth: `Bearer token or session cookie`
 
@@ -2777,13 +2807,15 @@ curl -H "Authorization: Bearer <USER_API_KEY>" \
       "error_message": null,
       "plan_json": null,
       "generation_id": "5bf1495b-b6fa-4318-841c-dced628a2c5b",
+      "total_cost_usd": 1.4628,
       "created_at": "2026-04-18 12:00:00",
       "updated_at": "2026-04-18 12:34:56"
     }
   ],
-  "known_models": {
-    "claude": ["opus"]
+  "available_models": {
+    "claude": [{"id": "opus", "name": "Claude Opus"}]
   },
+  "total_cost_usd": 1.23,
   "known_branches": {
     "for-testing-only": ["main", "dev"]
   }
@@ -2825,6 +2857,7 @@ curl -H "Authorization: Bearer <USER_API_KEY>" \
   "error_message": null,
   "plan_json": null,
   "generation_id": "5bf1495b-b6fa-4318-841c-dced628a2c5b",
+  "total_cost_usd": 1.4628,
   "created_at": "2026-04-18 12:00:00",
   "updated_at": "2026-04-18 12:34:56"
 }
@@ -2868,6 +2901,7 @@ curl -H "Authorization: Bearer <ADMIN_KEY>" \
       "error_message": null,
       "plan_json": null,
       "generation_id": "5bf1495b-b6fa-4318-841c-dced628a2c5b",
+      "total_cost_usd": 1.4628,
       "created_at": "2026-04-18 12:00:00",
       "updated_at": "2026-04-18 12:34:56"
     }
@@ -2919,6 +2953,7 @@ curl -H "Authorization: Bearer <ADMIN_KEY>" \
   "error_message": null,
   "plan_json": null,
   "generation_id": "5bf1495b-b6fa-4318-841c-dced628a2c5b",
+  "total_cost_usd": 1.4628,
   "created_at": "2026-04-18 12:00:00",
   "updated_at": "2026-04-18 12:34:56"
 }
@@ -3556,7 +3591,8 @@ Fields:
 | --- | --- | --- |
 | `type` | string | Always `sync`. |
 | `projects` | array of `ProjectVariant` | Full visible project snapshot. |
-| `known_models` | object | Same structure as `GET /api/projects`. |
+| `available_models` | object | Same structure as `GET /api/projects`. |
+| `total_cost_usd` | number | Same structure as `GET /api/projects`. |
 | `known_branches` | object | Same structure as `GET /api/projects`. |
 
 ```json
@@ -3578,13 +3614,15 @@ Fields:
       "error_message": null,
       "plan_json": null,
       "generation_id": "5bf1495b-b6fa-4318-841c-dced628a2c5b",
+      "total_cost_usd": 1.4628,
       "created_at": "2026-04-18 12:00:00",
       "updated_at": "2026-04-18 12:34:56"
     }
   ],
-  "known_models": {
-    "claude": ["opus"]
+  "available_models": {
+    "claude": [{"id": "opus", "name": "Claude Opus"}]
   },
+  "total_cost_usd": 1.23,
   "known_branches": {
     "for-testing-only": ["main", "dev"]
   }

--- a/frontend/src/components/shared/Combobox.tsx
+++ b/frontend/src/components/shared/Combobox.tsx
@@ -1,9 +1,10 @@
 import { useState, useRef, useEffect, useCallback, useId } from 'react'
 import { ChevronDown } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import type { ComboboxOption } from '@/types'
 
 interface ComboboxProps {
-  options: string[]
+  options: (string | ComboboxOption)[]
   value: string
   onChange: (value: string) => void
   placeholder?: string
@@ -29,8 +30,13 @@ export default function Combobox({
   const instanceId = useId()
   const listboxId = `combobox-listbox-${instanceId}`
 
-  const filtered = options.filter((opt) =>
-    opt.toLowerCase().includes(value.toLowerCase())
+  const normalizedOptions: ComboboxOption[] = options.map(opt =>
+    typeof opt === 'string' ? { value: opt, label: opt } : opt
+  )
+
+  const filtered = normalizedOptions.filter((opt) =>
+    opt.label.toLowerCase().includes(value.toLowerCase()) ||
+    opt.value.toLowerCase().includes(value.toLowerCase())
   )
 
   const closeDropdown = useCallback(() => {
@@ -71,7 +77,7 @@ export default function Combobox({
       // Only prevent default and commit when dropdown is open with a highlighted option
       if (isOpen && highlightedIndex >= 0 && highlightedIndex < filtered.length) {
         e.preventDefault()
-        onChange(filtered[highlightedIndex])
+        onChange(filtered[highlightedIndex].value)
         closeDropdown()
       }
     } else if (e.key === 'Escape') {
@@ -120,7 +126,7 @@ export default function Combobox({
         >
           {filtered.map((option, index) => (
             <li
-              key={`${index}-${option}`}
+              key={option.value}
               id={`combobox-option-${instanceId}-${index}`}
               role="option"
               aria-selected={index === highlightedIndex}
@@ -132,12 +138,15 @@ export default function Combobox({
               )}
               onMouseDown={(e) => {
                 e.preventDefault()
-                onChange(option)
+                onChange(option.value)
                 closeDropdown()
               }}
               onMouseEnter={() => setHighlightedIndex(index)}
             >
-              {option}
+              <span>{option.label}</span>
+              {option.label !== option.value && (
+                <span className="ml-1.5 text-xs text-muted-foreground">{option.value}</span>
+              )}
             </li>
           ))}
         </ul>

--- a/frontend/src/components/shared/GenerateForm.tsx
+++ b/frontend/src/components/shared/GenerateForm.tsx
@@ -14,6 +14,7 @@ import {
 import Combobox from '@/components/shared/Combobox'
 import { api } from '@/lib/api'
 import { TOAST_DEFAULT_MS, TOAST_ERROR_MS, VALID_PROVIDERS } from '@/lib/constants'
+import type { AvailableModels } from '@/types'
 import { ApiError } from '@/types'
 const DEFAULT_PROVIDER = 'cursor'
 const DEFAULT_BRANCH = 'main'
@@ -23,7 +24,7 @@ const SK_BRANCH = 'docsfy-branch'
 const SK_FORCE = 'docsfy-force'
 
 interface GenerateFormProps {
-  knownModels: Record<string, string[]>
+  availableModels: AvailableModels
   knownBranches: Record<string, string[]>
   onGenerated?: (name: string, branch: string, provider: string, model: string) => void
 }
@@ -38,7 +39,7 @@ function extractRepoName(url: string): string {
 }
 
 export default function GenerateForm({
-  knownModels,
+  availableModels,
   knownBranches,
   onGenerated,
 }: GenerateFormProps) {
@@ -52,10 +53,10 @@ export default function GenerateForm({
   // Determine the default model for a given provider
   const getDefaultModel = useCallback(
     (prov: string): string => {
-      const models = knownModels[prov]
-      return models && models.length > 0 ? models[0] : ''
+      const models = availableModels[prov]
+      return models && models.length > 0 ? models[0].id : ''
     },
-    [knownModels],
+    [availableModels],
   )
 
   // Restore form state from sessionStorage on mount
@@ -69,21 +70,20 @@ export default function GenerateForm({
     if (savedForce === 'true') setForce(true)
   }, [])
 
-  // Set default model when provider or knownModels changes.
-  // When knownModels arrives asynchronously (via API / WebSocket) and the
+  // Set default model when provider or availableModels changes.
+  // When availableModels arrives asynchronously (via API / WebSocket) and the
   // model field is still empty, this fills it with the first available model
   // for the current provider.
   useEffect(() => {
-    const models = knownModels[provider]
+    const models = availableModels[provider]
     if (!models || models.length === 0) return
 
     setModel((prev) => {
-      // Keep current model if it's valid for this provider
-      if (prev && models.includes(prev)) return prev
-      // Otherwise pick the first known model
-      return models[0]
+      // Only auto-fill when the field is empty.
+      // Explicit provider switches are handled in handleProviderChange().
+      return prev || models[0].id
     })
-  }, [provider, knownModels])
+  }, [provider, availableModels])
 
   function sanitizeRepoUrlForStorage(value: string): string {
     try {
@@ -124,10 +124,10 @@ export default function GenerateForm({
   function handleProviderChange(value: string) {
     setProvider(value)
     // Auto-fill model with first model for new provider if current model is not valid
-    const models = knownModels[value]
+    const models = availableModels[value]
     if (models && models.length > 0) {
-      if (!models.includes(model)) {
-        setModel(models[0])
+      if (!models.some(m => m.id === model)) {
+        setModel(models[0].id)
       }
     } else {
       setModel('')
@@ -180,7 +180,7 @@ export default function GenerateForm({
 
   const repoName = repoUrl.trim() ? extractRepoName(repoUrl) : ''
   const branchOptions = repoName && knownBranches[repoName] ? knownBranches[repoName] : []
-  const modelOptions = knownModels[provider] ?? []
+  const modelOptions = (availableModels[provider] ?? []).map(m => ({ value: m.id, label: m.name || m.id }))
 
   return (
     <div className="flex items-start justify-center h-full p-8">

--- a/frontend/src/components/shared/VariantDetail.tsx
+++ b/frontend/src/components/shared/VariantDetail.tsx
@@ -27,12 +27,12 @@ import { useModal } from '@/components/shared/ModalProvider'
 import { api } from '@/lib/api'
 import { TOAST_DEFAULT_MS, TOAST_ERROR_MS, VALID_PROVIDERS } from '@/lib/constants'
 import { ApiError } from '@/types'
-import type { Project, LogEntry, DocPlan } from '@/types'
+import type { Project, LogEntry, DocPlan, AvailableModels } from '@/types'
 
 interface VariantDetailProps {
   project: Project
   logEntries: LogEntry[]
-  knownModels: Record<string, string[]>
+  availableModels: AvailableModels
   isAdmin: boolean
   role: string
   onDelete?: () => void
@@ -202,6 +202,12 @@ function InfoGrid({ project, isAdmin }: { project: Project; isAdmin: boolean }) 
         <span className="text-muted-foreground">Last Generated</span>
         <div className="mt-0.5 font-medium">{formatDate(project.last_generated)}</div>
       </div>
+      {project.total_cost_usd != null && (
+        <div>
+          <span className="text-muted-foreground">Generation Cost</span>
+          <div className="mt-0.5 font-medium">${project.total_cost_usd.toFixed(4)}</div>
+        </div>
+      )}
       {project.generation_id && (
         <div>
           <span className="text-muted-foreground">Generation ID</span>
@@ -230,12 +236,12 @@ function InfoGrid({ project, isAdmin }: { project: Project; isAdmin: boolean }) 
 
 function RegenerateSection({
   project,
-  knownModels,
+  availableModels,
   defaultForce,
   onRegenerate,
 }: {
   project: Project
-  knownModels: Record<string, string[]>
+  availableModels: AvailableModels
   defaultForce: boolean
   onRegenerate?: (provider: string, model: string, force: boolean) => void
 }) {
@@ -255,29 +261,28 @@ function RegenerateSection({
 
   const getDefaultModel = useCallback(
     (prov: string): string => {
-      const models = knownModels[prov]
-      return models && models.length > 0 ? models[0] : ''
+      const models = availableModels[prov]
+      return models && models.length > 0 ? models[0].id : ''
     },
-    [knownModels],
+    [availableModels],
   )
 
   useEffect(() => {
     setModel((prev) => {
-      const models = knownModels[provider]
+      const models = availableModels[provider]
       if (models && models.length > 0) {
-        if (prev && models.includes(prev)) return prev
-        return models[0]
+        return prev || models[0].id
       }
       return prev
     })
-  }, [provider, knownModels])
+  }, [provider, availableModels])
 
   function handleProviderChange(value: string) {
     setProvider(value)
-    const models = knownModels[value]
+    const models = availableModels[value]
     if (models && models.length > 0) {
-      if (!models.includes(model)) {
-        setModel(models[0])
+      if (!models.some(m => m.id === model)) {
+        setModel(models[0].id)
       }
     } else {
       setModel(getDefaultModel(value))
@@ -304,7 +309,7 @@ function RegenerateSection({
     }
   }
 
-  const modelOptions = knownModels[provider] ?? []
+  const modelOptions = (availableModels[provider] ?? []).map(m => ({ value: m.id, label: m.name || m.id }))
 
   return (
     <div className="border-t border-dashed pt-4 mt-4">
@@ -350,7 +355,7 @@ function RegenerateSection({
         <Button
           data-testid="data-regenerate-variant"
           onClick={handleRegenerate}
-          disabled={isStarting}
+          disabled={isStarting || !model}
           className="w-full sm:w-auto"
           title="Re-generate documentation with these settings"
         >
@@ -371,7 +376,7 @@ function RegenerateSection({
 function ReadyView({
   project,
   logEntries,
-  knownModels,
+  availableModels,
   isAdmin,
   role,
   onDelete,
@@ -456,7 +461,7 @@ function ReadyView({
       {role !== 'viewer' && (
         <RegenerateSection
           project={project}
-          knownModels={knownModels}
+          availableModels={availableModels}
           defaultForce={false}
           onRegenerate={onRegenerate}
         />
@@ -556,7 +561,7 @@ function GeneratingView({
 function ErrorAbortedView({
   project,
   logEntries,
-  knownModels,
+  availableModels,
   isAdmin,
   role,
   onDelete,
@@ -604,7 +609,7 @@ function ErrorAbortedView({
         <>
           <RegenerateSection
             project={project}
-            knownModels={knownModels}
+            availableModels={availableModels}
             defaultForce={true}
             onRegenerate={onRegenerate}
           />
@@ -637,7 +642,7 @@ function ErrorAbortedView({
 export default function VariantDetail({
   project,
   logEntries,
-  knownModels,
+  availableModels,
   isAdmin,
   role,
   onDelete,
@@ -657,7 +662,7 @@ export default function VariantDetail({
         <ReadyView
           project={project}
           logEntries={logEntries}
-          knownModels={knownModels}
+          availableModels={availableModels}
           isAdmin={isAdmin}
           role={role}
           onDelete={onDelete}
@@ -676,7 +681,7 @@ export default function VariantDetail({
         <ErrorAbortedView
           project={project}
           logEntries={logEntries}
-          knownModels={knownModels}
+          availableModels={availableModels}
           isAdmin={isAdmin}
           role={role}
           onDelete={onDelete}

--- a/frontend/src/lib/websocket.ts
+++ b/frontend/src/lib/websocket.ts
@@ -98,8 +98,9 @@ class WebSocketManager {
         const syncMessage: WebSocketMessage = {
           type: 'sync' as const,
           projects: data.projects,
-          known_models: data.known_models,
           known_branches: data.known_branches,
+          available_models: data.available_models ?? {},
+          total_cost_usd: data.total_cost_usd ?? 0,
         }
         this.handlers.forEach(handler => handler(syncMessage))
       } catch {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -34,6 +34,7 @@ import type {
   LogEntry,
   DocPlan,
 } from '@/types'
+import type { AvailableModels } from '@/types'
 import { ApiError } from '@/types'
 
 type SelectedView =
@@ -57,7 +58,8 @@ export default function DashboardPage() {
   // Data state
   const [projects, setProjects] = useState<Project[]>([])
   const [projectsLoaded, setProjectsLoaded] = useState(false)
-  const [knownModels, setKnownModels] = useState<Record<string, string[]>>({})
+  const [availableModels, setAvailableModels] = useState<AvailableModels>({})
+  const [totalCostUsd, setTotalCostUsd] = useState<number>(0)
   const [knownBranches, setKnownBranches] = useState<Record<string, string[]>>({})
   const [searchQuery, setSearchQuery] = useState('')
   const [selectedView, setSelectedView] = useState<SelectedView>(() => {
@@ -122,7 +124,8 @@ export default function DashboardPage() {
         const data = await api.get<ProjectsResponse>('/api/projects')
         if (cancelled) return
         setProjects(data.projects)
-        setKnownModels(data.known_models)
+        setAvailableModels(data.available_models ?? {})
+        setTotalCostUsd(data.total_cost_usd ?? 0)
         setKnownBranches(data.known_branches)
       } catch {
         /* handled by api interceptor */
@@ -179,7 +182,8 @@ export default function DashboardPage() {
     if (message.type === 'sync') {
       console.debug('[Dashboard] WS sync received, projects:', message.projects.length)
       setProjects(message.projects)
-      setKnownModels(message.known_models)
+      setAvailableModels(message.available_models ?? {})
+      setTotalCostUsd(message.total_cost_usd ?? 0)
       setKnownBranches(message.known_branches)
     } else if (message.type === 'progress') {
       setProjects((prev) => {
@@ -192,7 +196,8 @@ export default function DashboardPage() {
           // Variant not yet in local state — trigger a full refresh
           api.get<ProjectsResponse>('/api/projects').then((data) => {
             setProjects(data.projects)
-            setKnownModels(data.known_models)
+            setAvailableModels(data.available_models ?? {})
+            setTotalCostUsd(data.total_cost_usd ?? 0)
             setKnownBranches(data.known_branches)
           }).catch(() => { /* best-effort */ })
           return prev
@@ -225,7 +230,8 @@ export default function DashboardPage() {
         if (!exists) {
           api.get<ProjectsResponse>('/api/projects').then((data) => {
             setProjects(data.projects)
-            setKnownModels(data.known_models)
+            setAvailableModels(data.available_models ?? {})
+            setTotalCostUsd(data.total_cost_usd ?? 0)
             setKnownBranches(data.known_branches)
           }).catch(() => { /* best-effort */ })
           return prev
@@ -297,7 +303,8 @@ export default function DashboardPage() {
         try {
           const data = await api.get<ProjectsResponse>('/api/projects')
           setProjects(data.projects)
-          setKnownModels(data.known_models)
+          setAvailableModels(data.available_models ?? {})
+          setTotalCostUsd(data.total_cost_usd ?? 0)
           setKnownBranches(data.known_branches)
         } catch {
           /* best-effort fallback */
@@ -463,7 +470,12 @@ export default function DashboardPage() {
         <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
           Projects
         </span>
-        <span className="text-[11px] text-muted-foreground" title={`${repoCount} unique repositories`}>{repoCount}</span>
+        <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
+          <span title={`${repoCount} unique repositories`}>{repoCount}</span>
+          {totalCostUsd > 0 && (
+            <span title="Total cost across all generations">· ${totalCostUsd.toFixed(2)}</span>
+          )}
+        </span>
       </div>
 
       {/* Project tree */}
@@ -562,7 +574,7 @@ export default function DashboardPage() {
         selectedView={selectedView}
         username={username}
         projects={projects}
-        knownModels={knownModels}
+        availableModels={availableModels}
         knownBranches={knownBranches}
         isAdmin={isAdmin}
         role={role}
@@ -732,7 +744,7 @@ function MainPanel({
   selectedView,
   username,
   projects,
-  knownModels,
+  availableModels,
   knownBranches,
   isAdmin,
   role,
@@ -743,7 +755,7 @@ function MainPanel({
   selectedView: SelectedView
   username: string
   projects: Project[]
-  knownModels: Record<string, string[]>
+  availableModels: AvailableModels
   knownBranches: Record<string, string[]>
   isAdmin: boolean
   role: string
@@ -766,7 +778,7 @@ function MainPanel({
   if (selectedView.type === 'generate') {
     return (
       <GenerateForm
-        knownModels={knownModels}
+        availableModels={availableModels}
         knownBranches={knownBranches}
         onGenerated={onGenerated}
       />
@@ -800,7 +812,7 @@ function MainPanel({
       <VariantDetail
         project={project}
         logEntries={logEntries}
-        knownModels={knownModels}
+        availableModels={availableModels}
         isAdmin={isAdmin}
         role={role}
         onDelete={() => onDelete(project.name, project.branch, project.ai_provider, project.ai_model, project.owner)}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,6 +1,12 @@
 export type ProjectStatus = 'generating' | 'ready' | 'error' | 'aborted'
 export type UserRole = 'admin' | 'user' | 'viewer'
 export type AIProvider = 'claude' | 'gemini' | 'cursor'
+export type AvailableModels = Record<string, Array<{id: string; name: string}>>
+
+export interface ComboboxOption {
+  value: string
+  label: string
+}
 
 export interface Project {
   name: string
@@ -16,6 +22,7 @@ export interface Project {
   page_count: number
   error_message: string | null
   plan_json: string | null
+  total_cost_usd: number | null
   generation_id: string | null
   created_at: string
   updated_at: string
@@ -64,8 +71,9 @@ export interface AuthResponse {
 
 export interface ProjectsResponse {
   projects: Project[]
-  known_models: Record<string, string[]>
   known_branches: Record<string, string[]>
+  available_models: AvailableModels
+  total_cost_usd: number
 }
 
 export interface CreateUserResponse {
@@ -89,8 +97,9 @@ export type WebSocketMessage = SyncMessage | ProgressMessage | StatusChangeMessa
 export interface SyncMessage {
   type: 'sync'
   projects: Project[]
-  known_models: Record<string, string[]>
   known_branches: Record<string, string[]>
+  available_models: AvailableModels
+  total_cost_usd: number
 }
 
 export interface ProgressMessage {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.3.0"
 description = "AI-powered documentation generator - generates polished static HTML docs from GitHub repos"
 requires-python = ">=3.12"
 dependencies = [
-    "ai-cli-runner",
+    "ai-cli-runner>=0.3.0",
     "fastapi",
     "uvicorn",
     "pydantic-settings",

--- a/skills/docsfy-generate-docs/SKILL.md
+++ b/skills/docsfy-generate-docs/SKILL.md
@@ -66,7 +66,7 @@ If health check fails, inform the user that the docsfy server is not reachable a
 |-----------|----------|------------|
 | Repository URL | Yes | Ask user or infer from current repo's git remote |
 | AI Provider | Yes | From `docsfy models --json` → `providers` array |
-| AI Model | Yes | From `docsfy models --json` → `known_models.<provider>` array |
+| AI Model | Yes | From `docsfy models --json` → `available_models.<provider>` array of `{id, name}` objects |
 | Branch | No | Default: `main` |
 | Output directory | No | Default: `docs/` |
 | Force regeneration | No | Only offered when re-generating an existing project |
@@ -117,15 +117,16 @@ Key fields per entry:
   "providers": ["claude", "gemini", "cursor"],
   "default_provider": "cursor",
   "default_model": "gpt-5.4-xhigh-fast",
-  "known_models": {
-    "claude": ["claude-opus-4-6[1m]"],
-    "cursor": ["composer-2-fast"]
+  "available_models": {
+    "claude": [{"id": "claude-opus-4-6", "name": "Claude Opus 4"}],
+    "cursor": [{"id": "composer-2-fast", "name": "Composer 2 Fast"}]
   }
 }
 ```
 
-Extract `providers` for provider selection and `known_models` for model selection.
-Note: not all providers may have entries in `known_models` (e.g., `gemini` above has no models listed).
+Extract `providers` for provider selection and `available_models` for model selection.
+Each model entry has `id` (use for API calls) and `name` (use for display).
+Note: not all providers may have entries in `available_models` (e.g., `gemini` above has no models listed).
 
 **Fallback behavior:**
 
@@ -152,10 +153,11 @@ Show the user what was used before and present smart defaults:
 - Force regeneration: **always offer `--force`** since this is a re-generation of an existing project.
   Show when it was last generated: "Last generated: {last_generated}"
 
-**Round 2** — After provider is selected, present models from `known_models.<selected_provider>`.
+**Round 2** — After provider is selected, present models from `available_models.<selected_provider>`.
+Use the `name` field for display and the `id` field for API calls.
 If the user kept the same provider as before, show the previous `ai_model` as first option "(Previously used)".
 Mark `default_model` as "(Recommended)" if it appears in the list and is different from the previous model.
-If `known_models` does not contain the selected provider or the array is empty,
+If `available_models` does not contain the selected provider or the array is empty,
 fall back to free-form model input.
 
 **If NO previous generation exists:**
@@ -164,10 +166,10 @@ fall back to free-form model input.
 output directory. Do NOT offer `--force` (it does nothing for new generations).
 
 **Round 2** — After provider is selected, present that provider's models from
-`known_models.<selected_provider>` as `AskUserQuestion` options.
+`available_models.<selected_provider>` as `AskUserQuestion` options (use `name` for display, `id` for value).
 If the provider matches `default_provider` and `default_model` appears in the list,
 mark it as "(Recommended)" in the AskUserQuestion options.
-If `known_models` does not contain the selected provider or the array is empty,
+If `available_models` does not contain the selected provider or the array is empty,
 fall back to free-form model input.
 
 ### GitHub Pages Setup (GitHub repos only)

--- a/src/docsfy/ai_client.py
+++ b/src/docsfy/ai_client.py
@@ -3,19 +3,25 @@ from __future__ import annotations
 from ai_cli_runner import (
     PROVIDERS,
     VALID_AI_PROVIDERS,
+    AIResult,
     ProviderConfig,
     call_ai_cli,
     check_ai_cli_available,
     get_ai_cli_timeout,
+    model_cache,
+    pricing_cache,
     run_parallel_with_limit,
 )
 
 __all__ = [
     "PROVIDERS",
     "VALID_AI_PROVIDERS",
+    "AIResult",
     "ProviderConfig",
     "call_ai_cli",
     "check_ai_cli_available",
     "get_ai_cli_timeout",
+    "model_cache",
+    "pricing_cache",
     "run_parallel_with_limit",
 ]

--- a/src/docsfy/api/projects.py
+++ b/src/docsfy/api/projects.py
@@ -17,7 +17,12 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from simple_logger.logger import get_logger
 
-from docsfy.ai_client import check_ai_cli_available
+from docsfy.ai_client import check_ai_cli_available, model_cache
+from docsfy.cost_tracker import (
+    CostAccumulator,
+    set_cost_accumulator,
+    reset_cost_accumulator,
+)
 from docsfy.config import get_settings
 from docsfy.generator import (
     generate_all_pages,
@@ -49,9 +54,9 @@ from docsfy.repository import (
 )
 from docsfy.storage import (
     _validate_name,
+    set_generation_cost,
     delete_project,
     get_known_branches,
-    get_known_models,
     get_latest_variant,
     get_project,
     get_project_access,
@@ -59,6 +64,7 @@ from docsfy.storage import (
     get_project_cache_dir,
     get_project_dir,
     get_project_site_dir,
+    get_total_cost,
     get_user_accessible_projects,
     list_projects,
     list_variants,
@@ -119,6 +125,7 @@ async def update_and_notify(
     plan_json: str | None = None,
     current_stage: str | None | object = None,
     generation_id: str | None = None,
+    total_cost_usd: float | None = None,
 ) -> None:
     """Update project status in DB and send WebSocket notification."""
     ups_kwargs: dict[str, Any] = {
@@ -135,6 +142,8 @@ async def update_and_notify(
         ups_kwargs["error_message"] = error_message
     if plan_json is not None:
         ups_kwargs["plan_json"] = plan_json
+    if total_cost_usd is not None:
+        ups_kwargs["total_cost_usd"] = total_cost_usd
 
     # Always pass current_stage through so that None clears the stage in the DB.
     ups_kwargs["current_stage"] = current_stage
@@ -528,7 +537,7 @@ async def _replace_variant(
     )
 
     # Notify connected clients so the deleted variant disappears from the UI
-    await notify_sync(owner)
+    await notify_sync()
 
 
 async def _run_generation(
@@ -544,12 +553,14 @@ async def _run_generation(
     generation_id: str | None = None,
 ) -> None:
     gen_key = f"{owner}/{project_name}/{branch}/{ai_provider}/{ai_model}"
+    cost_acc = CostAccumulator()
+    cost_token = set_cost_accumulator(cost_acc)
     try:
         cli_flags = ["--trust"] if ai_provider == "cursor" else None
-        available, msg = await check_ai_cli_available(
+        check_result = await check_ai_cli_available(
             ai_provider, ai_model, cli_flags=cli_flags
         )
-        if not available:
+        if not check_result.success:
             await update_and_notify(
                 gen_key,
                 project_name,
@@ -558,7 +569,7 @@ async def _run_generation(
                 status="error",
                 owner=owner,
                 branch=branch,
-                error_message=msg,
+                error_message=check_result.text,
                 generation_id=generation_id,
             )
             return
@@ -645,6 +656,30 @@ async def _run_generation(
             generation_id=generation_id,
         )
     finally:
+        reset_cost_accumulator(cost_token)
+        # Persist generation cost and re-sync so clients see the updated value
+        if cost_acc.call_count > 0:
+            try:
+                await set_generation_cost(
+                    project_name,
+                    ai_provider,
+                    ai_model,
+                    branch=branch,
+                    owner=owner,
+                    cost_usd=cost_acc.total_cost_usd,
+                )
+            except Exception as exc:
+                logger.warning(
+                    f"[{project_name}] Failed to persist generation cost "
+                    f"(${cost_acc.total_cost_usd:.4f} for {ai_provider}/{ai_model}): {exc}"
+                )
+            else:
+                try:
+                    await notify_sync()
+                except Exception as exc:
+                    logger.debug(
+                        f"[{project_name}] Failed to send cost sync notification: {exc}"
+                    )
         async with _gen_lock:
             _generating.pop(gen_key, None)
 
@@ -1169,6 +1204,18 @@ async def _resolve_latest_accessible_variant(
 # ---------------------------------------------------------------------------
 
 
+async def _load_available_models() -> dict[str, list[dict[str, str]]]:
+    """Load available models for all providers from ai-cli-runner's model cache."""
+    result: dict[str, list[dict[str, str]]] = {}
+    for provider in VALID_PROVIDERS:
+        try:
+            result[provider] = await model_cache.list_models(provider)
+        except Exception as exc:
+            logger.warning("Failed to list models for %s: %s", provider, exc)
+            result[provider] = []
+    return result
+
+
 async def build_projects_payload(username: str, is_admin: bool) -> dict[str, Any]:
     """Build the projects sync payload for the given user.
 
@@ -1182,32 +1229,42 @@ async def build_projects_payload(username: str, is_admin: bool) -> dict[str, Any
         projects = await list_projects(owner=username, accessible=accessible)
         known_branches = await get_known_branches(owner=username)
 
-    known_models = await get_known_models()
+    available_models = await _load_available_models()
+    total_cost = await get_total_cost(owner=None if is_admin else username)
     return {
         "projects": projects,
-        "known_models": known_models,
         "known_branches": known_branches,
+        "available_models": available_models,
+        "total_cost_usd": total_cost,
     }
 
 
 @router.get("/models")
 async def get_models_endpoint() -> dict[str, Any]:
-    """Return available AI providers, server defaults, and known models.
+    """Return available AI providers, server defaults, and available models.
 
+    Models are discovered from AI CLI tools (cursor) and LiteLLM pricing
+    data (claude, gemini) via ai-cli-runner's model cache.
     No authentication required -- this is a discovery endpoint.
     """
     settings = get_settings()
-    try:
-        known_models = await get_known_models()
-    except Exception as exc:
-        logger.warning(f"/api/models: failed to load known_models: {exc}")
-        known_models = {}
+    available_models = await _load_available_models()
     return {
         "providers": list(VALID_PROVIDERS),
         "default_provider": settings.ai_provider,
         "default_model": settings.ai_model,
-        "known_models": known_models,
+        "available_models": available_models,
     }
+
+
+@router.get("/cost")
+async def get_cost_endpoint(request: Request) -> dict[str, float]:
+    """Return total generation cost. Admins see all; users see their own."""
+    if request.state.is_admin:
+        total = await get_total_cost()
+    else:
+        total = await get_total_cost(owner=request.state.username)
+    return {"total_cost_usd": total}
 
 
 @router.get("/projects/by-id/{generation_id}")
@@ -1381,7 +1438,7 @@ async def get_variant_details(
     branch: str,
     provider: str,
     model: str,
-) -> dict[str, str | int | None]:
+) -> dict[str, str | int | float | None]:
     name = _validate_project_name(name)
     project = await _resolve_project(
         request,

--- a/src/docsfy/cli/projects.py
+++ b/src/docsfy/cli/projects.py
@@ -423,7 +423,7 @@ def models(
         typer.Option("--json", "-j", help="Output as JSON"),
     ] = False,
 ) -> None:
-    """List available AI providers and known models."""
+    """List available AI providers and available models."""
     from docsfy.cli.main import get_client
 
     client = get_client()
@@ -435,7 +435,7 @@ def models(
     providers = data.get("providers", [])
     default_provider = data.get("default_provider", "")
     default_model = data.get("default_model", "")
-    known = data.get("known_models", {})
+    available = data.get("available_models", {})
 
     if provider:
         if provider not in providers:
@@ -448,7 +448,7 @@ def models(
                 "providers": [provider],
                 "default_provider": default_provider,
                 "default_model": default_model,
-                "known_models": {provider: known.get(provider, [])},
+                "available_models": {provider: available.get(provider, [])},
             }
             typer.echo(json.dumps(filtered, indent=2))
         else:
@@ -464,15 +464,16 @@ def models(
             label += " (default)"
         typer.echo(label)
 
-        models_list = known.get(p, [])
+        models_list = available.get(p, [])
         if not models_list:
-            typer.echo("  (no models used yet)")
+            typer.echo("  (no models available)")
         else:
-            for m in models_list:
+            for entry in models_list:
+                model_id = entry.get("id", "") if isinstance(entry, dict) else entry
                 suffix = (
                     "  (default)"
-                    if p == default_provider and m == default_model
+                    if p == default_provider and model_id == default_model
                     else ""
                 )
-                typer.echo(f"  {m}{suffix}")
+                typer.echo(f"  {model_id}{suffix}")
         typer.echo()

--- a/src/docsfy/cost_tracker.py
+++ b/src/docsfy/cost_tracker.py
@@ -1,0 +1,61 @@
+"""Generation-scoped cost accumulator.
+
+Uses ``contextvars.ContextVar`` so that every ``call_ai_cli`` invocation
+within a generation run can add its cost without changing function signatures.
+
+Usage in the generation orchestrator (``_run_generation``)::
+
+    acc = CostAccumulator()
+    token = set_cost_accumulator(acc)
+    try:
+        ... # run planner, generate pages, validate, cross-link
+    finally:
+        reset_cost_accumulator(token)
+    total_cost = acc.total_cost_usd  # aggregated cost from all AI calls
+
+The ``add_cost`` helper is called from ``_call_ai_or_raise`` and direct
+``call_ai_cli`` call-sites — it's a no-op when no accumulator is active.
+"""
+
+from __future__ import annotations
+
+import contextvars
+from dataclasses import dataclass, field
+
+
+@dataclass
+class CostAccumulator:
+    """Asyncio-safe cost accumulator for a single generation run."""
+
+    total_cost_usd: float = field(default=0.0)
+    call_count: int = field(default=0)
+
+    def add(self, cost_usd: float | None) -> None:
+        """Record an AI CLI call. Always increments call_count; adds to total_cost_usd only for positive values."""
+        self.call_count += 1
+        if cost_usd is not None and cost_usd > 0:
+            self.total_cost_usd += cost_usd
+
+
+_cost_accumulator_var: contextvars.ContextVar[CostAccumulator | None] = (
+    contextvars.ContextVar("cost_accumulator", default=None)
+)
+
+
+def set_cost_accumulator(
+    acc: CostAccumulator,
+) -> contextvars.Token[CostAccumulator | None]:
+    """Set the active cost accumulator for this async context."""
+    return _cost_accumulator_var.set(acc)
+
+
+def reset_cost_accumulator(token: contextvars.Token[CostAccumulator | None]) -> None:
+    """Reset the cost accumulator to its previous value."""
+    _cost_accumulator_var.reset(token)
+
+
+def add_cost(cost_usd: float | None) -> None:
+    """Add cost to the active accumulator, if any. Safe to call unconditionally."""
+    acc = _cost_accumulator_var.get()
+    if acc is not None:
+        acc.add(cost_usd)

--- a/src/docsfy/generator.py
+++ b/src/docsfy/generator.py
@@ -10,7 +10,8 @@ from typing import Any
 
 from simple_logger.logger import get_logger
 
-from docsfy.ai_client import call_ai_cli, run_parallel_with_limit
+from docsfy.ai_client import AIResult, call_ai_cli, run_parallel_with_limit
+from docsfy.cost_tracker import add_cost
 from docsfy.json_parser import parse_json_array_response, parse_json_response
 from pydantic import ValidationError
 
@@ -95,18 +96,21 @@ async def _call_ai_or_raise(
     ai_model: str,
     ai_cli_timeout: int | None = None,
 ) -> str:
+    """Call AI CLI, accumulate cost, and raise on failure."""
     cli_flags = ["--trust"] if ai_provider == "cursor" else None
-    success, output = await call_ai_cli(
+    result: AIResult = await call_ai_cli(
         prompt=prompt,
         cwd=repo_path,
         ai_provider=ai_provider,
         ai_model=ai_model,
         ai_cli_timeout=ai_cli_timeout,
         cli_flags=cli_flags,
+        output_format="json",
     )
-    if not success:
-        raise RuntimeError(output)
-    return output
+    add_cost(result.usage.cost_usd if result.usage else None)
+    if not result.success:
+        raise RuntimeError(result.text[:2000])
+    return result.text
 
 
 def _normalize_incremental_planner_result(raw_result: list[Any]) -> list[str]:

--- a/src/docsfy/main.py
+++ b/src/docsfy/main.py
@@ -23,6 +23,7 @@ from docsfy.api.projects import (
     _validate_project_name,
     router as projects_router,
 )
+from docsfy.ai_client import pricing_cache
 from docsfy.config import get_settings
 from docsfy.models import DEFAULT_BRANCH
 from docsfy.storage import (
@@ -54,6 +55,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     _generating.clear()
     await init_db(data_dir=settings.data_dir)
+
+    try:
+        await pricing_cache.load()
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "pricing_cache.load() failed; cost tracking will be degraded", exc_info=True
+        )
+
     await cleanup_expired_sessions()
     yield
 

--- a/src/docsfy/postprocess.py
+++ b/src/docsfy/postprocess.py
@@ -13,7 +13,8 @@ from typing import Any
 
 from simple_logger.logger import get_logger
 
-from docsfy.ai_client import call_ai_cli, run_parallel_with_limit
+from docsfy.ai_client import AIResult, call_ai_cli, run_parallel_with_limit
+from docsfy.cost_tracker import add_cost
 from docsfy.generator import generate_full_page_content
 from docsfy.json_parser import parse_json_array_response, parse_json_response
 from docsfy.models import PAGE_TYPES
@@ -390,21 +391,25 @@ async def _validate_single_page(
 
     prompt = build_validation_prompt(str(temp_file))
     cli_flags = ["--trust"] if ai_provider == "cursor" else None
-    success, output = await call_ai_cli(
+    result: AIResult = await call_ai_cli(
         prompt=prompt,
         cwd=repo_path,
         ai_provider=ai_provider,
         ai_model=ai_model,
         ai_cli_timeout=ai_cli_timeout,
         cli_flags=cli_flags,
+        output_format="json",
     )
+    add_cost(result.usage.cost_usd if result.usage else None)
 
-    if not success:
+    if not result.success:
         logger.warning(f"[{project_name}] Validation AI call failed for page '{slug}'")
-        logger.debug(f"[{project_name}] Validation output for '{slug}': {output[:200]}")
+        logger.debug(
+            f"[{project_name}] Validation output for '{slug}': {result.text[:200]}"
+        )
         return content
 
-    stale_refs = parse_json_array_response(output)
+    stale_refs = parse_json_array_response(result.text)
     if stale_refs is None:
         logger.warning(
             f"[{project_name}] Validation returned invalid JSON for page '{slug}', keeping original content"
@@ -613,14 +618,16 @@ async def add_cross_links(
             pages_dir=str(pages_dir),
         )
         cli_flags = ["--trust"] if ai_provider == "cursor" else None
+        result: AIResult | None = None
         try:
-            success, output = await call_ai_cli(
+            result = await call_ai_cli(
                 prompt=prompt,
                 cwd=repo_path,
                 ai_provider=ai_provider,
                 ai_model=ai_model,
                 ai_cli_timeout=ai_cli_timeout,
                 cli_flags=cli_flags,
+                output_format="json",
             )
         except Exception as exc:
             logger.warning(
@@ -630,13 +637,19 @@ async def add_cross_links(
     finally:
         shutil.rmtree(pages_dir, ignore_errors=True)
 
-    if not success:
+    add_cost(result.usage.cost_usd if result and result.usage else None)
+
+    if result is None or not result.success:
         logger.warning(
             f"[{project_name}] add_cross_links: AI call failed, returning pages unchanged"
         )
+        if result is not None:
+            logger.debug(
+                f"[{project_name}] add_cross_links output: {result.text[:200]}"
+            )
         return pages
 
-    cross_links = parse_json_response(output)
+    cross_links = parse_json_response(result.text)
     if not isinstance(cross_links, dict):
         logger.warning(
             f"[{project_name}] add_cross_links: Invalid AI cross-links response, returning pages unchanged"

--- a/src/docsfy/storage.py
+++ b/src/docsfy/storage.py
@@ -77,6 +77,7 @@ async def init_db(data_dir: str = "") -> None:
                 page_count INTEGER DEFAULT 0,
                 error_message TEXT,
                 plan_json TEXT,
+                total_cost_usd REAL,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 PRIMARY KEY (name, branch, ai_provider, ai_model, owner)
@@ -147,6 +148,7 @@ async def init_db(data_dir: str = "") -> None:
                     page_count INTEGER DEFAULT 0,
                     error_message TEXT,
                     plan_json TEXT,
+                    total_cost_usd REAL,
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     PRIMARY KEY (name, branch, ai_provider, ai_model, owner)
@@ -193,6 +195,11 @@ async def init_db(data_dir: str = "") -> None:
             select_cols.append("page_count")
             select_cols.append("error_message")
             select_cols.append("plan_json")
+            select_cols.append(
+                "total_cost_usd"
+                if "total_cost_usd" in old_columns
+                else "NULL AS total_cost_usd"
+            )
             select_cols.append("created_at")
             select_cols.append("updated_at")
 
@@ -200,13 +207,22 @@ async def init_db(data_dir: str = "") -> None:
                 INSERT OR IGNORE INTO projects_new
                     (name, branch, ai_provider, ai_model, owner, generation_id, repo_url, status, current_stage,
                      last_commit_sha, last_generated, page_count, error_message,
-                     plan_json, created_at, updated_at)
+                     plan_json, total_cost_usd, created_at, updated_at)
                 SELECT {", ".join(select_cols)}
                 FROM projects
             """)
             await db.execute("DROP TABLE projects")
             await db.execute("ALTER TABLE projects_new RENAME TO projects")
             logger.info("Database migration to 5-column PK complete")
+
+        # Migration: add total_cost_usd column
+        try:
+            await db.execute("ALTER TABLE projects ADD COLUMN total_cost_usd REAL")
+            await db.commit()
+        except sqlite3.OperationalError as exc:
+            if "duplicate column name" not in str(exc).lower():
+                logger.exception("Migration failed while adding total_cost_usd column")
+                raise
 
         # Migration: add generation_id column
         try:
@@ -350,6 +366,7 @@ async def save_project(
                generation_id = COALESCE(projects.generation_id, excluded.generation_id),
                error_message = NULL,
                current_stage = NULL,
+               total_cost_usd = NULL,
                updated_at = CURRENT_TIMESTAMP""",
             (
                 name,
@@ -388,13 +405,14 @@ async def update_project_status(
     error_message: str | None = None,
     plan_json: str | None = None,
     current_stage: str | None | object = _UNSET,
+    total_cost_usd: float | None = None,
 ) -> None:
     if status not in VALID_STATUSES:
         msg = f"Invalid project status: '{status}'. Valid: {', '.join(sorted(VALID_STATUSES))}"
         raise ValueError(msg)
     async with aiosqlite.connect(DB_PATH) as db:
         fields = ["status = ?", "updated_at = CURRENT_TIMESTAMP"]
-        values: list[str | int | None] = [status]
+        values: list[str | int | float | None] = [status]
         if current_stage is not _UNSET:
             fields.append("current_stage = ?")
             values.append(current_stage)  # type: ignore[arg-type]
@@ -410,6 +428,9 @@ async def update_project_status(
         if plan_json is not None:
             fields.append("plan_json = ?")
             values.append(plan_json)
+        if total_cost_usd is not None:
+            fields.append("total_cost_usd = ?")
+            values.append(total_cost_usd)
         if status == "ready":
             fields.append("last_generated = CURRENT_TIMESTAMP")
         values.append(name)
@@ -426,6 +447,52 @@ async def update_project_status(
             values,
         )
         await db.commit()
+
+
+async def set_generation_cost(
+    name: str,
+    ai_provider: str,
+    ai_model: str,
+    cost_usd: float,
+    branch: str = DEFAULT_BRANCH,
+    owner: str = "",
+) -> None:
+    """Set (overwrite) the generation cost for a specific variant."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "UPDATE projects SET total_cost_usd = ? WHERE name = ? AND branch = ? AND ai_provider = ? AND ai_model = ? AND owner = ?",
+            (cost_usd, name, branch, ai_provider, ai_model, owner),
+        )
+        await db.commit()
+        if db.total_changes == 0:
+            logger.warning(
+                "set_generation_cost: no matching variant for %s/%s/%s (branch=%s, owner=%s)",
+                name,
+                ai_provider,
+                ai_model,
+                branch,
+                owner,
+            )
+
+
+async def get_total_cost(owner: str | None = None) -> float:
+    """Return the sum of total_cost_usd across project variants.
+
+    When *owner* is provided, only sums costs for that owner's projects.
+    When ``None``, sums all projects (admin view).
+    """
+    async with aiosqlite.connect(DB_PATH) as db:
+        if owner is not None:
+            cursor = await db.execute(
+                "SELECT COALESCE(SUM(total_cost_usd), 0) FROM projects WHERE owner = ?",
+                (owner,),
+            )
+        else:
+            cursor = await db.execute(
+                "SELECT COALESCE(SUM(total_cost_usd), 0) FROM projects"
+            )
+        row = await cursor.fetchone()
+        return float(row[0]) if row else 0.0
 
 
 async def get_project(
@@ -694,22 +761,6 @@ async def get_latest_variant(
         cursor = await db.execute(query, params)
         row = await cursor.fetchone()
         return dict(row) if row else None
-
-
-async def get_known_models() -> dict[str, list[str]]:
-    """Get distinct ai_model values per ai_provider from completed projects."""
-    async with aiosqlite.connect(DB_PATH) as db:
-        cursor = await db.execute(
-            "SELECT DISTINCT ai_provider, ai_model FROM projects WHERE ai_provider != '' AND ai_model != '' AND status = 'ready' ORDER BY ai_provider, ai_model"
-        )
-        rows = await cursor.fetchall()
-        models: dict[str, list[str]] = {}
-        for provider, model in rows:
-            if provider not in models:
-                models[provider] = []
-            if model not in models[provider]:
-                models[provider].append(model)
-        return models
 
 
 async def get_known_branches(owner: str | None = None) -> dict[str, list[str]]:

--- a/test-plans/e2e-14-models-command.md
+++ b/test-plans/e2e-14-models-command.md
@@ -28,7 +28,7 @@ docsfy models
 - The output lists all known providers (e.g., `claude`, `gemini`, `cursor`)
 - The server's default provider is marked with `(default)` next to its name
 - The server's default model is marked with `(default)` next to its name under the default provider
-- Each provider section shows its known models or `(no models used yet)` if none exist
+- Each provider section shows its discovered models or `(no models available)` if none exist
 
 ---
 
@@ -43,8 +43,8 @@ docsfy models --provider cursor
 **Expected result:**
 - Only the `cursor` provider is listed
 - No other providers appear in the output
-- If `cursor` has known models from completed generations, they are shown
-- If not, `(no models used yet)` is displayed
+- If `cursor` has discovered models from provider APIs, they are shown
+- If not, `(no models available)` is displayed
 
 ---
 
@@ -74,16 +74,16 @@ docsfy models --json
 **Check:**
 
 ```shell
-docsfy models --json | python3 -c "import sys,json; data=json.load(sys.stdin); assert 'providers' in data; assert 'default_provider' in data; assert 'default_model' in data; assert 'known_models' in data; print('Valid JSON with all required keys')"
+docsfy models --json | python3 -c "import sys,json; data=json.load(sys.stdin); assert 'providers' in data; assert 'default_provider' in data; assert 'default_model' in data; assert 'available_models' in data; print('Valid JSON with all required keys')"
 ```
 
 **Expected result:**
 - The output is valid JSON
-- The JSON contains the keys `providers`, `default_provider`, `default_model`, and `known_models`
+- The JSON contains the keys `providers`, `default_provider`, `default_model`, and `available_models`
 - `providers` is a list containing the known provider names (e.g., `["claude", "gemini", "cursor"]`)
 - `default_provider` is a string matching one of the providers
 - `default_model` is a string
-- `known_models` is an object keyed by provider name
+- `available_models` is an object keyed by provider name, where each value is an array of `{id, name}` objects
 
 ---
 
@@ -98,12 +98,12 @@ docsfy models --json --provider gemini
 **Check:**
 
 ```shell
-docsfy models --json --provider gemini | python3 -c "import sys,json; data=json.load(sys.stdin); assert data['providers'] == ['gemini'], f'Expected [\"gemini\"], got {data[\"providers\"]}'; assert list(data['known_models'].keys()) == ['gemini'], f'Expected only gemini key in known_models, got {list(data[\"known_models\"].keys())}'; print('Filtered JSON is correct')"
+docsfy models --json --provider gemini | python3 -c "import sys,json; data=json.load(sys.stdin); assert data['providers'] == ['gemini'], f'Expected [\"gemini\"], got {data[\"providers\"]}'; assert list(data['available_models'].keys()) == ['gemini'], f'Expected only gemini key in available_models, got {list(data[\"available_models\"].keys())}'; print('Filtered JSON is correct')"
 ```
 
 **Expected result:**
 - The JSON output contains only `gemini` in the `providers` list
-- The `known_models` object contains only the `gemini` key
+- The `available_models` object contains only the `gemini` key
 - `default_provider` and `default_model` are still present (they reflect the server defaults, not the filter)
 
 ---
@@ -123,77 +123,62 @@ curl -s -o /dev/null -w "%{http_code}" "$DOCSFY_SERVER/api/models"
 **Verify response body:**
 
 ```shell
-curl -s "$DOCSFY_SERVER/api/models" | python3 -c "import sys,json; data=json.load(sys.stdin); assert 'providers' in data; assert 'default_provider' in data; assert 'default_model' in data; assert 'known_models' in data; print('API response is valid')"
+curl -s "$DOCSFY_SERVER/api/models" | python3 -c "import sys,json; data=json.load(sys.stdin); assert 'providers' in data; assert 'default_provider' in data; assert 'default_model' in data; assert 'available_models' in data; print('API response is valid')"
 ```
 
 **Expected result:**
 - The response is valid JSON with the same schema as the CLI `--json` output
-- Contains `providers`, `default_provider`, `default_model`, and `known_models`
+- Contains `providers`, `default_provider`, `default_model`, and `available_models`
 
 ---
 
-### 28.7 Response includes known_models from completed generations
+### 28.7 Response includes available_models from provider discovery
 
-**Precondition:** At least one generation must have completed successfully. If no prior test has generated docs, trigger one first.
+**Precondition:** The server must be running and able to discover models from configured AI providers.
 
-**Check for existing completed generation:**
+**Check for available models:**
 
 ```shell
-COMPLETED=$(curl -s "$DOCSFY_SERVER/api/models" | python3 -c "
+AVAILABLE=$(curl -s "$DOCSFY_SERVER/api/models" | python3 -c "
 import sys, json
 data = json.load(sys.stdin)
-known = data.get('known_models', {})
-total = sum(len(v) for v in known.values())
+available = data.get('available_models', {})
+total = sum(len(v) for v in available.values())
 print(total)
 ")
-echo "Known models count: $COMPLETED"
+echo "Available models count: $AVAILABLE"
 ```
 
-If 0, generate docs to populate known_models:
-
-```shell
-if [ "$COMPLETED" = "0" ]; then
-  docsfy generate https://github.com/myk-org/for-testing-only --provider gemini --model gemini-2.5-flash --force
-  for i in $(seq 1 60); do
-    STATUS=$(curl -s "$DOCSFY_SERVER/api/projects" -H "Authorization: Bearer $DOCSFY_API_KEY" | python3 -c "import sys,json; data=json.load(sys.stdin); matches=[p for p in data['projects'] if p['name']=='for-testing-only' and p['branch']=='main' and p['ai_model']=='gemini-2.5-flash']; print(matches[0].get('status','') if matches else 'not_found')")
-    echo "Poll $i: status=$STATUS"
-    if [ "$STATUS" = "ready" ] || [ "$STATUS" = "error" ] || [ "$STATUS" = "aborted" ]; then break; fi
-    sleep 2
-  done
-fi
-```
-
-**Verify known_models contains data:**
+**Verify available_models contains data:**
 
 ```shell
 curl -s "$DOCSFY_SERVER/api/models" | python3 -c "
 import sys, json
 data = json.load(sys.stdin)
-known = data.get('known_models', {})
-assert isinstance(known, dict), 'known_models should be a dict'
-total = sum(len(v) for v in known.values())
-assert total > 0, 'known_models should contain at least one model after generation'
-# Verify the model we generated with is present
-gemini_models = known.get('gemini', [])
-assert 'gemini-2.5-flash' in gemini_models, f'Expected gemini-2.5-flash in known gemini models, got {gemini_models}'
-print(f'known_models contains {total} model(s) across {len(known)} provider(s)')
-print(f'gemini models: {gemini_models}')
+available = data.get('available_models', {})
+assert isinstance(available, dict), 'available_models should be a dict'
+total = sum(len(v) for v in available.values())
+assert total > 0, 'available_models should contain at least one model'
+# Verify models have the correct shape: [{id, name}, ...]
+for provider, models in available.items():
+    for m in models:
+        assert 'id' in m and 'name' in m, f'Model entry missing id/name: {m}'
+# Verify at least one provider has discovered models
+providers_with_models = [p for p, m in available.items() if len(m) > 0]
+assert len(providers_with_models) > 0, f'Expected at least one provider with models, got {available}'
+print(f'available_models contains {total} model(s) across {len(available)} provider(s)')
+print(f'Providers with models: {providers_with_models}')
 "
 ```
 
 **Expected result:**
-- `known_models` is a dictionary keyed by provider name
-- The `gemini` key contains `gemini-2.5-flash` (from the completed generation)
-- Models from completed generations are accurately reflected in the response
+- `available_models` is a dictionary keyed by provider name
+- Each value is an array of objects with `id` and `name` fields (e.g., `[{"id": "gemini-2.5-flash", "name": "Gemini 2.5 Flash"}, ...]`)
+- At least one provider has discovered models
+- Models are discovered from AI CLI tools and LiteLLM pricing data, not from completed generations
 
 ---
 
 ### 28.8 Cleanup
 
-**Delete any generation created by test 28.7:**
-
-```shell
-docsfy delete for-testing-only --branch main --provider gemini --model gemini-2.5-flash --yes 2>/dev/null || true
-```
-
-**Expected result:** Variant is deleted or already gone.
+**No cleanup needed.** Test 28.7 only queries available models and does not create any variant.

--- a/test-plans/e2e-ui-test-plan.md
+++ b/test-plans/e2e-ui-test-plan.md
@@ -164,7 +164,7 @@ Each linked sub-file contains only the detailed test bodies for its assigned sec
 | [e2e-11-websocket.md](e2e-11-websocket.md) | 23 | WebSocket Connection, Auth, Real-time Updates |
 | [e2e-12-cli.md](e2e-12-cli.md) | 24 | CLI Commands (config, generate, list, status, admin) |
 | [e2e-13-post-generation-pipeline.md](e2e-13-post-generation-pipeline.md) | 27 | Post-Generation Pipeline (version footer, related pages, validation/cross-linking stages, performance) |
-| [e2e-14-models-command.md](e2e-14-models-command.md) | 28 | Models Command (CLI providers/models listing, JSON output, API endpoint, known_models) |
+| [e2e-14-models-command.md](e2e-14-models-command.md) | 28 | Models Command (CLI providers/models listing, JSON output, API endpoint, available_models) |
 | [e2e-09-cleanup.md](e2e-09-cleanup.md) | 21 | Cleanup and Teardown |
 
 **`e2e-09-cleanup.md` must always be executed last, after all other test files.**
@@ -202,4 +202,18 @@ Each linked sub-file contains only the detailed test bodies for its assigned sec
 | 26 | Dialog Theme Consistency | 26.1-26.2 |
 | 27 | Post-Generation Pipeline | 27.1-27.8 |
 | 28 | Models Command | 28.1-28.8 |
+| 29 | Cost Tracking | 29.1-29.6 |
 | 21 | Cleanup and Teardown | 21.1-21.5 |
+
+---
+
+### Cost Tracking
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 1 | Generate docs and wait for completion | Generation completes successfully |
+| 2 | Check sidebar header | Shows total cost (e.g., `$1.46`) next to project count |
+| 3 | Click on the completed variant | Variant detail shows "Generation Cost" field with dollar amount |
+| 4 | Call `GET /api/cost` | Returns `{"total_cost_usd": <positive number>}` |
+| 5 | Call `GET /api/projects` | Response includes `total_cost_usd` at top level |
+| 6 | Check variant in projects list | Each variant object has `total_cost_usd` field |

--- a/tests/test_api_projects.py
+++ b/tests/test_api_projects.py
@@ -52,12 +52,12 @@ async def client(tmp_path: Path):
 
 
 async def test_list_projects_empty(client: AsyncClient) -> None:
-    """GET /api/projects returns empty list with known_models and known_branches."""
+    """GET /api/projects returns empty list with available_models and known_branches."""
     response = await client.get("/api/status")
     assert response.status_code == 200
     data = response.json()
     assert data["projects"] == []
-    assert "known_models" in data
+    assert "available_models" in data
     assert "known_branches" in data
 
 
@@ -88,16 +88,16 @@ async def test_get_project_not_found(client: AsyncClient) -> None:
 
 
 async def test_get_models_returns_valid_structure(client: AsyncClient) -> None:
-    """GET /api/models returns providers, defaults, and known_models."""
+    """GET /api/models returns providers, defaults, and available_models."""
     response = await client.get("/api/models")
     assert response.status_code == 200
     data = response.json()
     assert "providers" in data
     assert "default_provider" in data
     assert "default_model" in data
-    assert "known_models" in data
+    assert "available_models" in data
     assert isinstance(data["providers"], list)
-    assert isinstance(data["known_models"], dict)
+    assert isinstance(data["available_models"], dict)
 
 
 async def test_get_models_includes_valid_providers(client: AsyncClient) -> None:
@@ -152,3 +152,13 @@ async def test_get_models_no_auth_required() -> None:
             storage.DATA_DIR = orig_data
             storage.PROJECTS_DIR = orig_projects
             get_settings.cache_clear()
+
+
+async def test_get_cost_returns_total(client: AsyncClient) -> None:
+    """GET /api/cost returns total_cost_usd."""
+    response = await client.get("/api/cost")
+    assert response.status_code == 200
+    data = response.json()
+    assert "total_cost_usd" in data
+    assert isinstance(data["total_cost_usd"], (int, float))
+    assert data["total_cost_usd"] >= 0

--- a/tests/test_cli_projects.py
+++ b/tests/test_cli_projects.py
@@ -319,9 +319,9 @@ class TestModels:
             "providers": ["claude", "gemini", "cursor"],
             "default_provider": "cursor",
             "default_model": "gpt-5.4-xhigh-fast",
-            "known_models": {
-                "cursor": ["gpt-5.4-xhigh-fast"],
-                "claude": ["sonnet-4"],
+            "available_models": {
+                "cursor": [{"id": "gpt-5.4-xhigh-fast", "name": "GPT 5.4"}],
+                "claude": [{"id": "sonnet-4", "name": "Sonnet 4"}],
             },
         }
         result = runner.invoke(app, ["models"])
@@ -335,8 +335,11 @@ class TestModels:
             "providers": ["claude", "cursor"],
             "default_provider": "cursor",
             "default_model": "gpt-5.4-xhigh-fast",
-            "known_models": {
-                "cursor": ["gpt-5.4-xhigh-fast", "gpt-4"],
+            "available_models": {
+                "cursor": [
+                    {"id": "gpt-5.4-xhigh-fast", "name": "GPT 5.4"},
+                    {"id": "gpt-4", "name": "GPT 4"},
+                ],
             },
         }
         result = runner.invoke(app, ["models"])
@@ -356,9 +359,9 @@ class TestModels:
             "providers": ["claude", "gemini", "cursor"],
             "default_provider": "cursor",
             "default_model": "gpt-5.4-xhigh-fast",
-            "known_models": {
-                "claude": ["sonnet-4"],
-                "cursor": ["gpt-5.4-xhigh-fast"],
+            "available_models": {
+                "claude": [{"id": "sonnet-4", "name": "Sonnet 4"}],
+                "cursor": [{"id": "gpt-5.4-xhigh-fast", "name": "GPT 5.4"}],
             },
         }
         result = runner.invoke(app, ["models", "--provider", "claude"])
@@ -373,31 +376,31 @@ class TestModels:
             "providers": ["claude", "gemini", "cursor"],
             "default_provider": "cursor",
             "default_model": "gpt-5.4-xhigh-fast",
-            "known_models": {},
+            "available_models": {},
         }
         result = runner.invoke(app, ["models", "--provider", "invalid"])
         assert result.exit_code == 1
         assert "Unknown provider" in result.output
 
-    def test_models_no_models_yet(self, mock_client: MagicMock) -> None:
+    def test_models_no_models_available(self, mock_client: MagicMock) -> None:
         mock_client.get_models.return_value = {
             "providers": ["claude", "gemini", "cursor"],
             "default_provider": "cursor",
             "default_model": "gpt-5.4-xhigh-fast",
-            "known_models": {},
+            "available_models": {},
         }
         result = runner.invoke(app, ["models"])
         assert result.exit_code == 0
-        assert "(no models used yet)" in result.output
+        assert "(no models available)" in result.output
 
     def test_models_json_output(self, mock_client: MagicMock) -> None:
         api_data = {
             "providers": ["claude", "gemini", "cursor"],
             "default_provider": "cursor",
             "default_model": "gpt-5.4-xhigh-fast",
-            "known_models": {
-                "cursor": ["gpt-5.4-xhigh-fast"],
-                "claude": ["sonnet-4"],
+            "available_models": {
+                "cursor": [{"id": "gpt-5.4-xhigh-fast", "name": "GPT 5.4"}],
+                "claude": [{"id": "sonnet-4", "name": "Sonnet 4"}],
             },
         }
         mock_client.get_models.return_value = api_data
@@ -411,9 +414,9 @@ class TestModels:
             "providers": ["claude", "gemini", "cursor"],
             "default_provider": "cursor",
             "default_model": "gpt-5.4-xhigh-fast",
-            "known_models": {
-                "cursor": ["gpt-5.4-xhigh-fast"],
-                "claude": ["sonnet-4"],
+            "available_models": {
+                "cursor": [{"id": "gpt-5.4-xhigh-fast", "name": "GPT 5.4"}],
+                "claude": [{"id": "sonnet-4", "name": "Sonnet 4"}],
             },
         }
         result = runner.invoke(app, ["models", "--json", "--provider", "claude"])
@@ -422,9 +425,11 @@ class TestModels:
         assert data["providers"] == ["claude"]
         assert data["default_provider"] == "cursor"
         assert data["default_model"] == "gpt-5.4-xhigh-fast"
-        assert data["known_models"] == {"claude": ["sonnet-4"]}
+        assert data["available_models"] == {
+            "claude": [{"id": "sonnet-4", "name": "Sonnet 4"}]
+        }
         # Must not contain other providers' models
-        assert "cursor" not in data["known_models"]
+        assert "cursor" not in data["available_models"]
 
 
 class TestDownload:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from ai_cli_runner import AIResult
 
 
 @pytest.fixture
@@ -36,7 +37,8 @@ async def test_run_planner(tmp_path: Path, sample_plan: dict) -> None:
     from docsfy.generator import run_planner
 
     with patch(
-        "docsfy.generator.call_ai_cli", return_value=(True, json.dumps(sample_plan))
+        "docsfy.generator.call_ai_cli",
+        return_value=AIResult(success=True, text=json.dumps(sample_plan)),
     ):
         plan = await run_planner(
             repo_path=tmp_path,
@@ -53,7 +55,10 @@ async def test_run_planner(tmp_path: Path, sample_plan: dict) -> None:
 async def test_run_planner_ai_failure(tmp_path: Path) -> None:
     from docsfy.generator import run_planner
 
-    with patch("docsfy.generator.call_ai_cli", return_value=(False, "AI error")):
+    with patch(
+        "docsfy.generator.call_ai_cli",
+        return_value=AIResult(success=False, text="AI error"),
+    ):
         with pytest.raises(RuntimeError, match="AI error"):
             await run_planner(
                 repo_path=tmp_path,
@@ -66,7 +71,10 @@ async def test_run_planner_ai_failure(tmp_path: Path) -> None:
 async def test_run_planner_bad_json(tmp_path: Path) -> None:
     from docsfy.generator import run_planner
 
-    with patch("docsfy.generator.call_ai_cli", return_value=(True, "not json")):
+    with patch(
+        "docsfy.generator.call_ai_cli",
+        return_value=AIResult(success=True, text="not json"),
+    ):
         with pytest.raises(RuntimeError, match="Failed to parse"):
             await run_planner(
                 repo_path=tmp_path,
@@ -84,7 +92,7 @@ async def test_generate_page(tmp_path: Path) -> None:
 
     with patch(
         "docsfy.generator.call_ai_cli",
-        return_value=(True, "# Introduction\n\nWelcome!"),
+        return_value=AIResult(success=True, text="# Introduction\n\nWelcome!"),
     ):
         md = await generate_page(
             repo_path=tmp_path,
@@ -121,7 +129,7 @@ async def test_generate_page_applies_incremental_updates(tmp_path: Path) -> None
 
     with patch(
         "docsfy.generator.call_ai_cli",
-        return_value=(True, incremental_response),
+        return_value=AIResult(success=True, text=incremental_response),
     ):
         md = await generate_page(
             repo_path=tmp_path,
@@ -163,8 +171,8 @@ async def test_generate_page_falls_back_to_full_generation_on_invalid_incrementa
     with patch(
         "docsfy.generator.call_ai_cli",
         side_effect=[
-            (True, invalid_incremental_response),
-            (True, full_page_response),
+            AIResult(success=True, text=invalid_incremental_response),
+            AIResult(success=True, text=full_page_response),
         ],
     ) as mock_call:
         md = await generate_page(
@@ -211,7 +219,7 @@ async def test_run_incremental_planner(tmp_path: Path, sample_plan: dict) -> Non
 
     with patch(
         "docsfy.generator.call_ai_cli",
-        return_value=(True, '["introduction"]'),
+        return_value=AIResult(success=True, text='["introduction"]'),
     ):
         result = await run_incremental_planner(
             repo_path=tmp_path,
@@ -232,7 +240,7 @@ async def test_run_incremental_planner_preserves_empty_result(
 
     with patch(
         "docsfy.generator.call_ai_cli",
-        return_value=(True, "[]"),
+        return_value=AIResult(success=True, text="[]"),
     ):
         result = await run_incremental_planner(
             repo_path=tmp_path,
@@ -253,7 +261,7 @@ async def test_run_incremental_planner_returns_all_on_non_string_items(
 
     with patch(
         "docsfy.generator.call_ai_cli",
-        return_value=(True, '[1, "valid", null]'),
+        return_value=AIResult(success=True, text='[1, "valid", null]'),
     ):
         result = await run_incremental_planner(
             repo_path=tmp_path,
@@ -274,7 +282,7 @@ async def test_run_incremental_planner_returns_all_on_mixed_all_and_slug(
 
     with patch(
         "docsfy.generator.call_ai_cli",
-        return_value=(True, '["all", "introduction"]'),
+        return_value=AIResult(success=True, text='["all", "introduction"]'),
     ):
         result = await run_incremental_planner(
             repo_path=tmp_path,
@@ -295,7 +303,7 @@ async def test_run_incremental_planner_returns_all_on_empty_slug(
 
     with patch(
         "docsfy.generator.call_ai_cli",
-        return_value=(True, '["   "]'),
+        return_value=AIResult(success=True, text='["   "]'),
     ):
         result = await run_incremental_planner(
             repo_path=tmp_path,
@@ -316,7 +324,9 @@ async def test_run_incremental_planner_deduplicates_and_trims_slugs(
 
     with patch(
         "docsfy.generator.call_ai_cli",
-        return_value=(True, '[" introduction ", "introduction", "quickstart"]'),
+        return_value=AIResult(
+            success=True, text='[" introduction ", "introduction", "quickstart"]'
+        ),
     ):
         result = await run_incremental_planner(
             repo_path=tmp_path,
@@ -337,7 +347,7 @@ async def test_run_incremental_planner_returns_all_on_failure(
 
     with patch(
         "docsfy.generator.call_ai_cli",
-        return_value=(False, "AI error"),
+        return_value=AIResult(success=False, text="AI error"),
     ):
         result = await run_incremental_planner(
             repo_path=tmp_path,
@@ -358,7 +368,7 @@ async def test_run_incremental_planner_returns_all_on_bad_json(
 
     with patch(
         "docsfy.generator.call_ai_cli",
-        return_value=(True, "not json at all"),
+        return_value=AIResult(success=True, text="not json at all"),
     ):
         result = await run_incremental_planner(
             repo_path=tmp_path,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from ai_cli_runner import AIResult
 from httpx import ASGITransport, AsyncClient
 
 TEST_ADMIN_KEY = "test-admin-secret-key"
@@ -71,7 +72,10 @@ async def test_full_flow_mock(client: AsyncClient, tmp_path: Path) -> None:
     }
 
     with (
-        patch("docsfy.api.projects.check_ai_cli_available", return_value=(True, "")),
+        patch(
+            "docsfy.api.projects.check_ai_cli_available",
+            return_value=AIResult(success=True, text=""),
+        ),
         patch(
             "docsfy.api.projects.clone_repo",
             return_value=(tmp_path / "repo", "abc123", "main"),
@@ -184,7 +188,10 @@ async def test_full_flow_with_branch(client: AsyncClient, tmp_path: Path) -> Non
         return (tmp_path / "repo", "def456", "v2.0")
 
     with (
-        patch("docsfy.api.projects.check_ai_cli_available", return_value=(True, "")),
+        patch(
+            "docsfy.api.projects.check_ai_cli_available",
+            return_value=AIResult(success=True, text=""),
+        ),
         patch("docsfy.api.projects.clone_repo", side_effect=mock_clone),
         patch("docsfy.api.projects.run_planner", return_value=sample_plan),
         patch(

--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from ai_cli_runner import AIResult
 
 
 def test_detect_version_pyproject_toml(tmp_path: Path) -> None:
@@ -108,7 +109,9 @@ async def test_validate_pages_no_issues(tmp_path: Path) -> None:
     from docsfy.postprocess import validate_pages
 
     pages = {"intro": "# Introduction\nThis is valid content."}
-    with patch("docsfy.postprocess.call_ai_cli", return_value=(True, "[]")):
+    with patch(
+        "docsfy.postprocess.call_ai_cli", return_value=AIResult(success=True, text="[]")
+    ):
         result = await validate_pages(
             pages=pages,
             repo_path=tmp_path,
@@ -144,7 +147,10 @@ async def test_validate_pages_with_stale_references(tmp_path: Path) -> None:
     )
     regen_content = "# Introduction\nUses the new React dashboard."
     with (
-        patch("docsfy.postprocess.call_ai_cli", return_value=(True, stale_refs)),
+        patch(
+            "docsfy.postprocess.call_ai_cli",
+            return_value=AIResult(success=True, text=stale_refs),
+        ),
         patch(
             "docsfy.postprocess.generate_full_page_content",
             return_value=regen_content,
@@ -167,7 +173,10 @@ async def test_validate_pages_ai_failure_preserves_pages(tmp_path: Path) -> None
     from docsfy.postprocess import validate_pages
 
     pages = {"intro": "# Introduction\nOriginal content."}
-    with patch("docsfy.postprocess.call_ai_cli", return_value=(False, "AI error")):
+    with patch(
+        "docsfy.postprocess.call_ai_cli",
+        return_value=AIResult(success=False, text="AI error"),
+    ):
         result = await validate_pages(
             pages=pages,
             repo_path=tmp_path,
@@ -219,7 +228,10 @@ async def test_add_cross_links(tmp_path: Path) -> None:
             "api": ["intro", "config"],
         }
     )
-    with patch("docsfy.postprocess.call_ai_cli", return_value=(True, cross_links_json)):
+    with patch(
+        "docsfy.postprocess.call_ai_cli",
+        return_value=AIResult(success=True, text=cross_links_json),
+    ):
         result = await add_cross_links(
             pages=pages,
             plan=plan,
@@ -246,7 +258,10 @@ async def test_add_cross_links_ai_failure_preserves_pages(tmp_path: Path) -> Non
             }
         ]
     }
-    with patch("docsfy.postprocess.call_ai_cli", return_value=(False, "AI error")):
+    with patch(
+        "docsfy.postprocess.call_ai_cli",
+        return_value=AIResult(success=False, text="AI error"),
+    ):
         result = await add_cross_links(
             pages=pages,
             plan=plan,
@@ -266,7 +281,9 @@ async def test_validate_pages_passes_ai_cli_timeout(tmp_path: Path) -> None:
     from docsfy.postprocess import validate_pages
 
     pages = {"intro": "# Intro\nContent."}
-    with patch("docsfy.postprocess.call_ai_cli", return_value=(True, "[]")) as mock_cli:
+    with patch(
+        "docsfy.postprocess.call_ai_cli", return_value=AIResult(success=True, text="[]")
+    ) as mock_cli:
         await validate_pages(
             pages=pages,
             repo_path=tmp_path,
@@ -279,6 +296,7 @@ async def test_validate_pages_passes_ai_cli_timeout(tmp_path: Path) -> None:
     mock_cli.assert_called_once()
     _, kwargs = mock_cli.call_args
     assert kwargs.get("ai_cli_timeout") == 42
+    assert kwargs.get("output_format") == "json"
 
 
 @pytest.mark.asyncio
@@ -287,7 +305,9 @@ async def test_validate_pages_cursor_passes_trust_flag(tmp_path: Path) -> None:
     from docsfy.postprocess import validate_pages
 
     pages = {"intro": "# Intro\nContent."}
-    with patch("docsfy.postprocess.call_ai_cli", return_value=(True, "[]")) as mock_cli:
+    with patch(
+        "docsfy.postprocess.call_ai_cli", return_value=AIResult(success=True, text="[]")
+    ) as mock_cli:
         await validate_pages(
             pages=pages,
             repo_path=tmp_path,
@@ -307,7 +327,9 @@ async def test_validate_pages_non_cursor_no_trust_flag(tmp_path: Path) -> None:
     from docsfy.postprocess import validate_pages
 
     pages = {"intro": "# Intro\nContent."}
-    with patch("docsfy.postprocess.call_ai_cli", return_value=(True, "[]")) as mock_cli:
+    with patch(
+        "docsfy.postprocess.call_ai_cli", return_value=AIResult(success=True, text="[]")
+    ) as mock_cli:
         await validate_pages(
             pages=pages,
             repo_path=tmp_path,
@@ -338,7 +360,10 @@ async def test_validate_pages_passes_timeout_to_regen(tmp_path: Path) -> None:
     stale_refs = json.dumps([{"reference": "old_feature", "reason": "removed"}])
     regen_content = "# Intro\nNew content."
     with (
-        patch("docsfy.postprocess.call_ai_cli", return_value=(True, stale_refs)),
+        patch(
+            "docsfy.postprocess.call_ai_cli",
+            return_value=AIResult(success=True, text=stale_refs),
+        ),
         patch(
             "docsfy.postprocess.generate_full_page_content",
             return_value=regen_content,
@@ -378,7 +403,8 @@ async def test_add_cross_links_passes_ai_cli_timeout(tmp_path: Path) -> None:
     }
     cross_links_json = json.dumps({"intro": ["api"]})
     with patch(
-        "docsfy.postprocess.call_ai_cli", return_value=(True, cross_links_json)
+        "docsfy.postprocess.call_ai_cli",
+        return_value=AIResult(success=True, text=cross_links_json),
     ) as mock_cli:
         await add_cross_links(
             pages=pages,
@@ -391,6 +417,7 @@ async def test_add_cross_links_passes_ai_cli_timeout(tmp_path: Path) -> None:
     mock_cli.assert_called_once()
     _, kwargs = mock_cli.call_args
     assert kwargs.get("ai_cli_timeout") == 77
+    assert kwargs.get("output_format") == "json"
 
 
 @pytest.mark.asyncio
@@ -408,7 +435,8 @@ async def test_add_cross_links_cursor_passes_trust_flag(tmp_path: Path) -> None:
         ]
     }
     with patch(
-        "docsfy.postprocess.call_ai_cli", return_value=(True, json.dumps({}))
+        "docsfy.postprocess.call_ai_cli",
+        return_value=AIResult(success=True, text=json.dumps({})),
     ) as mock_cli:
         await add_cross_links(
             pages=pages,
@@ -437,7 +465,8 @@ async def test_add_cross_links_non_cursor_no_trust_flag(tmp_path: Path) -> None:
         ]
     }
     with patch(
-        "docsfy.postprocess.call_ai_cli", return_value=(True, json.dumps({}))
+        "docsfy.postprocess.call_ai_cli",
+        return_value=AIResult(success=True, text=json.dumps({})),
     ) as mock_cli:
         await add_cross_links(
             pages=pages,
@@ -468,7 +497,7 @@ async def test_validate_single_page_empty_exclusions_returns_original(
     with (
         patch(
             "docsfy.postprocess.call_ai_cli",
-            return_value=(True, stale_refs_no_reference),
+            return_value=AIResult(success=True, text=stale_refs_no_reference),
         ),
         patch("docsfy.postprocess.generate_full_page_content") as mock_regen,
     ):
@@ -505,7 +534,10 @@ async def test_add_cross_links_accepts_project_name_parameter(
             }
         ]
     }
-    with patch("docsfy.postprocess.call_ai_cli", return_value=(True, json.dumps({}))):
+    with patch(
+        "docsfy.postprocess.call_ai_cli",
+        return_value=AIResult(success=True, text=json.dumps({})),
+    ):
         result = await add_cross_links(
             pages=pages,
             plan=plan,
@@ -534,7 +566,10 @@ async def test_add_cross_links_ai_failure_includes_project_name_in_log(
         ]
     }
     with (
-        patch("docsfy.postprocess.call_ai_cli", return_value=(False, "AI error")),
+        patch(
+            "docsfy.postprocess.call_ai_cli",
+            return_value=AIResult(success=False, text="AI error"),
+        ),
         patch("docsfy.postprocess.logger") as mock_logger,
     ):
         result = await add_cross_links(
@@ -569,7 +604,10 @@ async def test_add_cross_links_parse_failure_includes_project_name_in_log(
         ]
     }
     with (
-        patch("docsfy.postprocess.call_ai_cli", return_value=(True, "invalid json")),
+        patch(
+            "docsfy.postprocess.call_ai_cli",
+            return_value=AIResult(success=True, text="invalid json"),
+        ),
         patch("docsfy.postprocess.logger") as mock_logger,
     ):
         result = await add_cross_links(
@@ -602,7 +640,7 @@ async def test_validate_single_page_parse_failure_logs_warning(
     with (
         patch(
             "docsfy.postprocess.call_ai_cli",
-            return_value=(True, "not valid json at all"),
+            return_value=AIResult(success=True, text="not valid json at all"),
         ),
         patch("docsfy.postprocess.logger") as mock_logger,
     ):
@@ -631,7 +669,10 @@ async def test_validate_single_page_empty_list_no_warning(
 
     pages = {"intro": "# Intro\nContent."}
     with (
-        patch("docsfy.postprocess.call_ai_cli", return_value=(True, "[]")),
+        patch(
+            "docsfy.postprocess.call_ai_cli",
+            return_value=AIResult(success=True, text="[]"),
+        ),
         patch("docsfy.postprocess.logger") as mock_logger,
     ):
         result = await validate_pages(
@@ -702,7 +743,10 @@ async def test_add_cross_links_non_dict_json_returns_pages_unchanged(
     # Mock parse_json_response to return a list (non-dict) directly,
     # so we test the isinstance(cross_links, dict) guard, not parse failure
     with (
-        patch("docsfy.postprocess.call_ai_cli", return_value=(True, '["intro"]')),
+        patch(
+            "docsfy.postprocess.call_ai_cli",
+            return_value=AIResult(success=True, text='["intro"]'),
+        ),
         patch("docsfy.postprocess.parse_json_response", return_value=["intro"]),
         patch("docsfy.postprocess.logger") as mock_logger,
     ):
@@ -779,7 +823,10 @@ async def test_validate_pages_uses_confined_paths(tmp_path: Path) -> None:
 
     pages = {"../../etc/passwd": "# Malicious\nContent."}
     with (
-        patch("docsfy.postprocess.call_ai_cli", return_value=(True, "[]")),
+        patch(
+            "docsfy.postprocess.call_ai_cli",
+            return_value=AIResult(success=True, text="[]"),
+        ),
         patch("docsfy.postprocess.logger") as mock_logger,
     ):
         result = await validate_pages(
@@ -819,7 +866,10 @@ async def test_add_cross_links_uses_confined_paths(tmp_path: Path) -> None:
             }
         ]
     }
-    with patch("docsfy.postprocess.call_ai_cli", return_value=(True, json.dumps({}))):
+    with patch(
+        "docsfy.postprocess.call_ai_cli",
+        return_value=AIResult(success=True, text=json.dumps({})),
+    ):
         with pytest.raises(ValueError, match="Unsafe generated filename"):
             await add_cross_links(
                 pages=pages,
@@ -855,7 +905,10 @@ async def test_add_cross_links_skips_self_links(tmp_path: Path) -> None:
     }
     # AI suggests intro links to itself and config
     cross_links_json = json.dumps({"intro": ["intro", "config"]})
-    with patch("docsfy.postprocess.call_ai_cli", return_value=(True, cross_links_json)):
+    with patch(
+        "docsfy.postprocess.call_ai_cli",
+        return_value=AIResult(success=True, text=cross_links_json),
+    ):
         result = await add_cross_links(
             pages=pages,
             plan=plan,
@@ -890,7 +943,10 @@ async def test_add_cross_links_deduplicates(tmp_path: Path) -> None:
     }
     # AI suggests config twice
     cross_links_json = json.dumps({"intro": ["config", "config"]})
-    with patch("docsfy.postprocess.call_ai_cli", return_value=(True, cross_links_json)):
+    with patch(
+        "docsfy.postprocess.call_ai_cli",
+        return_value=AIResult(success=True, text=cross_links_json),
+    ):
         result = await add_cross_links(
             pages=pages,
             plan=plan,
@@ -922,7 +978,10 @@ async def test_add_cross_links_caps_at_five(tmp_path: Path) -> None:
     }
     # AI suggests 7 related pages for page0
     cross_links_json = json.dumps({"page0": slugs[1:]})
-    with patch("docsfy.postprocess.call_ai_cli", return_value=(True, cross_links_json)):
+    with patch(
+        "docsfy.postprocess.call_ai_cli",
+        return_value=AIResult(success=True, text=cross_links_json),
+    ):
         result = await add_cross_links(
             pages=pages,
             plan=plan,
@@ -951,7 +1010,7 @@ async def test_validate_pages_ai_failure_does_not_log_raw_output(
     with (
         patch(
             "docsfy.postprocess.call_ai_cli",
-            return_value=(False, raw_output),
+            return_value=AIResult(success=False, text=raw_output),
         ),
         patch("docsfy.postprocess.logger") as mock_logger,
     ):
@@ -1001,7 +1060,10 @@ async def test_add_cross_links_escapes_markdown_in_titles(tmp_path: Path) -> Non
         ]
     }
     cross_links_json = json.dumps({"intro": ["special"]})
-    with patch("docsfy.postprocess.call_ai_cli", return_value=(True, cross_links_json)):
+    with patch(
+        "docsfy.postprocess.call_ai_cli",
+        return_value=AIResult(success=True, text=cross_links_json),
+    ):
         result = await add_cross_links(
             pages=pages,
             plan=plan,
@@ -1038,7 +1100,10 @@ async def test_add_cross_links_fallback_to_slug_for_unknown_pages(
     }
     # AI suggests linking intro -> extra (extra is in pages but not in plan)
     cross_links_json = json.dumps({"intro": ["extra"]})
-    with patch("docsfy.postprocess.call_ai_cli", return_value=(True, cross_links_json)):
+    with patch(
+        "docsfy.postprocess.call_ai_cli",
+        return_value=AIResult(success=True, text=cross_links_json),
+    ):
         result = await add_cross_links(
             pages=pages,
             plan=plan,

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -146,63 +146,6 @@ async def test_get_nonexistent_project(db_path: Path) -> None:
     assert project is None
 
 
-async def test_get_known_models(db_path: Path) -> None:
-    from docsfy.storage import get_known_models, save_project, update_project_status
-
-    await save_project(
-        name="repo-a",
-        repo_url="https://github.com/org/a.git",
-        status="generating",
-        ai_provider="claude",
-        ai_model="opus-4-6",
-        owner="testuser",
-    )
-    await update_project_status(
-        "repo-a",
-        "claude",
-        "opus-4-6",
-        status="ready",
-        owner="testuser",
-    )
-    await save_project(
-        name="repo-b",
-        repo_url="https://github.com/org/b.git",
-        status="generating",
-        ai_provider="claude",
-        ai_model="sonnet-4-6",
-        owner="testuser",
-    )
-    await update_project_status(
-        "repo-b",
-        "claude",
-        "sonnet-4-6",
-        status="ready",
-        owner="testuser",
-    )
-    await save_project(
-        name="repo-c",
-        repo_url="https://github.com/org/c.git",
-        status="generating",
-        ai_provider="gemini",
-        ai_model="gemini-2.5-pro",
-        owner="testuser",
-    )
-    await update_project_status(
-        "repo-c",
-        "gemini",
-        "gemini-2.5-pro",
-        status="ready",
-        owner="testuser",
-    )
-
-    models = await get_known_models()
-    assert "claude" in models
-    assert "opus-4-6" in models["claude"]
-    assert "sonnet-4-6" in models["claude"]
-    assert "gemini" in models
-    assert "gemini-2.5-pro" in models["gemini"]
-
-
 async def test_init_db_resets_orphaned_generating(db_path: Path) -> None:
     from docsfy.storage import get_project, init_db, save_project
 
@@ -946,3 +889,185 @@ async def test_get_known_branches(db_path: Path) -> None:
     assert "main" in branches["repo1"]
     assert "v2.0" in branches["repo1"]
     assert "dev" not in branches["repo1"]
+
+
+async def test_set_generation_cost(tmp_path: Path) -> None:
+    """set_generation_cost sets total_cost_usd on a variant."""
+    import docsfy.storage as storage
+
+    orig_db = storage.DB_PATH
+    orig_projects = storage.PROJECTS_DIR
+    orig_data = storage.DATA_DIR
+    try:
+        storage.DB_PATH = tmp_path / "test.db"
+        storage.PROJECTS_DIR = tmp_path / "projects"
+        await storage.init_db(data_dir=str(tmp_path))
+
+        await storage.save_project(
+            name="cost-test",
+            repo_url="https://github.com/test/repo",
+            ai_provider="cursor",
+            ai_model="gpt-5",
+            owner="user1",
+        )
+        await storage.update_project_status(
+            "cost-test",
+            "cursor",
+            "gpt-5",
+            status="ready",
+            owner="user1",
+        )
+        await storage.set_generation_cost(
+            "cost-test",
+            "cursor",
+            "gpt-5",
+            cost_usd=1.23,
+            owner="user1",
+        )
+
+        project = await storage.get_project(
+            "cost-test",
+            ai_provider="cursor",
+            ai_model="gpt-5",
+            owner="user1",
+        )
+        assert project is not None
+        assert project["total_cost_usd"] == 1.23
+    finally:
+        storage.DB_PATH = orig_db
+        storage.PROJECTS_DIR = orig_projects
+        storage.DATA_DIR = orig_data
+
+
+async def test_get_total_cost(tmp_path: Path) -> None:
+    """get_total_cost sums total_cost_usd across all variants."""
+    import docsfy.storage as storage
+
+    orig_db = storage.DB_PATH
+    orig_projects = storage.PROJECTS_DIR
+    orig_data = storage.DATA_DIR
+    try:
+        storage.DB_PATH = tmp_path / "test.db"
+        storage.PROJECTS_DIR = tmp_path / "projects"
+        await storage.init_db(data_dir=str(tmp_path))
+
+        # Empty DB
+        total = await storage.get_total_cost()
+        assert total == 0.0
+
+        # Add two variants with costs
+        for i, cost in enumerate([0.50, 1.75]):
+            await storage.save_project(
+                name=f"proj-{i}",
+                repo_url="https://github.com/test/repo",
+                ai_provider="cursor",
+                ai_model="gpt-5",
+                owner="user1",
+            )
+            await storage.update_project_status(
+                f"proj-{i}",
+                "cursor",
+                "gpt-5",
+                status="ready",
+                owner="user1",
+            )
+            await storage.set_generation_cost(
+                f"proj-{i}",
+                "cursor",
+                "gpt-5",
+                cost_usd=cost,
+                owner="user1",
+            )
+
+        total = await storage.get_total_cost()
+        assert total == pytest.approx(2.25)
+    finally:
+        storage.DB_PATH = orig_db
+        storage.PROJECTS_DIR = orig_projects
+        storage.DATA_DIR = orig_data
+
+
+async def test_get_total_cost_owner_scoped(tmp_path: Path) -> None:
+    """get_total_cost(owner=...) only sums that owner's costs."""
+    import docsfy.storage as storage
+
+    orig_db = storage.DB_PATH
+    orig_data = storage.DATA_DIR
+    orig_projects = storage.PROJECTS_DIR
+    try:
+        storage.DB_PATH = tmp_path / "test.db"
+        storage.PROJECTS_DIR = tmp_path / "projects"
+        await storage.init_db(data_dir=str(tmp_path))
+
+        # Two owners with different costs
+        for owner, cost in [("alice", 1.00), ("bob", 2.50)]:
+            await storage.save_project(
+                name=f"proj-{owner}",
+                repo_url="https://github.com/test/repo",
+                ai_provider="cursor",
+                ai_model="gpt-5",
+                owner=owner,
+            )
+            await storage.set_generation_cost(
+                f"proj-{owner}",
+                "cursor",
+                "gpt-5",
+                cost_usd=cost,
+                owner=owner,
+            )
+
+        assert await storage.get_total_cost(owner="alice") == pytest.approx(1.00)
+        assert await storage.get_total_cost(owner="bob") == pytest.approx(2.50)
+        assert await storage.get_total_cost() == pytest.approx(3.50)
+    finally:
+        storage.DB_PATH = orig_db
+        storage.DATA_DIR = orig_data
+        storage.PROJECTS_DIR = orig_projects
+
+
+async def test_save_project_resets_cost(tmp_path: Path) -> None:
+    """save_project resets total_cost_usd to NULL for a new generation."""
+    import docsfy.storage as storage
+
+    orig_db = storage.DB_PATH
+    orig_projects = storage.PROJECTS_DIR
+    orig_data = storage.DATA_DIR
+    try:
+        storage.DB_PATH = tmp_path / "test.db"
+        storage.PROJECTS_DIR = tmp_path / "projects"
+        await storage.init_db(data_dir=str(tmp_path))
+
+        await storage.save_project(
+            name="reset-test",
+            repo_url="https://github.com/test/repo",
+            ai_provider="cursor",
+            ai_model="gpt-5",
+            owner="user1",
+        )
+        await storage.set_generation_cost(
+            "reset-test",
+            "cursor",
+            "gpt-5",
+            cost_usd=5.00,
+            owner="user1",
+        )
+        # Re-save (new generation) should reset cost
+        await storage.save_project(
+            name="reset-test",
+            repo_url="https://github.com/test/repo",
+            ai_provider="cursor",
+            ai_model="gpt-5",
+            owner="user1",
+        )
+        project = await storage.get_project(
+            "reset-test",
+            ai_provider="cursor",
+            ai_model="gpt-5",
+            owner="user1",
+        )
+        assert project is not None
+        assert project["total_cost_usd"] is None
+    finally:
+        storage.DB_PATH = orig_db
+        storage.PROJECTS_DIR = orig_projects
+        storage.DATA_DIR = orig_data

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -69,7 +69,9 @@ def test_websocket_accepts_bearer_token(sync_client: TestClient) -> None:
         data = ws.receive_json()
         assert data["type"] == "sync"
         assert "projects" in data
-        assert "known_models" in data
+        assert "available_models" in data
+        assert "total_cost_usd" in data
+        assert isinstance(data["total_cost_usd"], (int, float))
         assert "known_branches" in data
         # projects should be a list (possibly empty)
         assert isinstance(data["projects"], list)

--- a/uv.lock
+++ b/uv.lock
@@ -4,12 +4,13 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "ai-cli-runner"
-version = "0.1.0"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "httpx" },
     { name = "python-simple-logger" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/bb/7ae7870b6e07bae5a322c29b27f06c62efb0323543cdc4be6e8e6f9106e0/ai_cli_runner-0.1.0.tar.gz", hash = "sha256:c40b1eb5ec14976d7ee23cdb015b1cce79aad39a205057c018986c361d5afafd", size = 20564, upload-time = "2026-03-04T11:51:39.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/a2/a03bd995c8278ea985423ad0401c328195480ff74b7e1d846b87faad5721/ai_cli_runner-0.3.0.tar.gz", hash = "sha256:bbb0cdf1ecb80203aa3d659e631ed13123dbb2ee1ac0b78a2c76a8e5ed45bd90", size = 45632, upload-time = "2026-05-04T16:05:43.296Z" }
 
 [[package]]
 name = "aiosqlite"
@@ -123,7 +124,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ai-cli-runner" },
+    { name = "ai-cli-runner", specifier = ">=0.3.0" },
     { name = "aiosqlite" },
     { name = "fastapi" },
     { name = "httpx" },


### PR DESCRIPTION
## Summary

Upgrades `ai-cli-runner` from 0.1.0 to 0.3.0 to use real-time model discovery and per-generation cost tracking.

## Changes

### Model Discovery
- `/api/models` and WebSocket sync now return `available_models` with `{id, name}` per provider via `model_cache.list_models()` — replaces the old DB-based `known_models` (which only remembered previously-used models)
- Extracted `_load_available_models()` helper to avoid duplication
- Model combobox updated to show display names with IDs (e.g. **Composer 2 Fast** `composer-2-fast`)

### Cost Tracking
- All `call_ai_cli` calls use `output_format="json"` to get structured `AIResult` with token usage and cost metadata
- `CostAccumulator` (via `contextvars`) aggregates cost across all AI calls within a generation run — no function signature changes needed
- Per-generation cost stored in `total_cost_usd` DB column (with migration)
- Server-wide total via `GET /api/cost` and in sync payload
- Frontend: per-variant cost in info grid, total cost in sidebar header

### Cleanup
- Removed all `known_models` / `knownModels` backward-compat code
- Removed dead re-exports (`AIModelCache`, `AITokenUsage`, `LLMPricingCache`)
- All `AIResult` usage is direct (no tuple unpacking)
- Added `develop.watch` to docker-compose for auto-rebuild on dependency changes

### Tests
- 4 new tests for cost persistence and `/api/cost` endpoint
- All test mocks updated from tuples to `AIResult`
- 375/375 tests pass

## Manual Testing
- ✅ Model dropdown shows 79 cursor, 21 claude, 57 gemini models with display names
- ✅ Generation cost tracked ($1.46 for claude-haiku-4-5 on for-testing-only)
- ✅ Total cost in sidebar and `/api/cost` endpoint
- ✅ Per-variant cost in detail view info grid

Closes #68

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generation cost tracking (per-variant and aggregated total shown in Projects sidebar) and a new GET /api/cost endpoint
  * Model discovery exposed as per-provider available_models (id + name); UI model lists, selection, validation, and regenerate flows improved; Combobox selection/display enhanced

* **Documentation**
  * API, WebSocket, CLI, and guides updated to use available_models and total_cost_usd; examples and TOC updated

* **Tests**
  * E2E and unit tests updated to new schemas and cost endpoint

* **Chores**
  * AI CLI dependency constraint tightened
<!-- end of auto-generated comment: release notes by coderabbit.ai -->