### PR TITLE
fix: strip AI artifacts before parsing planner JSON output

### DIFF
--- a/src/docsfy/generator.py
+++ b/src/docsfy/generator.py
@@ -288,8 +288,13 @@ async def run_planner(
         ai_cli_timeout=ai_cli_timeout,
     )
 
-    plan = parse_json_response(output)
+    plan = parse_json_response(_strip_ai_artifacts(output))
     if plan is None:
+        logger.warning(
+            f"[{project_name}] Planner output is not valid JSON "
+            f"({len(output)} chars). Use DEBUG level to see content."
+        )
+        logger.debug(f"[{project_name}] Planner output preview: {output[:500]}")
         msg = "Failed to parse planner output as JSON"
         raise RuntimeError(msg)
 
@@ -566,7 +571,7 @@ async def run_incremental_planner(
     finally:
         shutil.rmtree(job_dir, ignore_errors=True)
 
-    raw_result = parse_json_array_response(output)
+    raw_result = parse_json_array_response(_strip_ai_artifacts(output))
     if raw_result is None or not isinstance(raw_result, list):
         logger.warning(
             f"[{project_name}] Incremental planner returned unparseable output, "


### PR DESCRIPTION
## Summary

Fixes cursor/gpt-5.4-xhigh-fast failing during planning with "Failed to parse planner output as JSON".

## Root Cause

Cursor models with thinking enabled wrap their response in `<think>...</think>` blocks containing braces, which confuse the JSON brace-matching extractor into grabbing the wrong `{...}` block.

## Fix

- Strip `<think>` blocks via `_strip_ai_artifacts()` before JSON parsing in `run_planner` and `run_incremental_planner`
- Added `logger.warning` with first 500 chars of raw output on parse failure for debugging

Closes #69

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preprocesses AI-generated planner output to remove extraneous AI artifacts, reducing parsing errors.
  * Applies the same preprocessing to incremental planning flows for more reliable results.
  * Improves error reporting when a plan can't be parsed by including output size and a brief preview to aid diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->