### PR TITLE
feat: add repo_type system for type-aware documentation generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,11 +28,11 @@ When adding new code:
 
 | Resource Type | Location | Examples |
 |---|---|---|
-| Python constants | `src/docsfy/models.py` | `VALID_PROVIDERS`, `DEFAULT_BRANCH`, `PAGE_TYPES`, `DOCSFY_DOCS_URL`, `DOCSFY_REPO_URL` |
-| Data models | `src/docsfy/models.py` | `GenerateRequest`, `DocPlan`, `DocPage`, `NavGroup` |
+| Python constants | `src/docsfy/models.py` | `VALID_PROVIDERS`, `DEFAULT_BRANCH`, `PAGE_TYPES`, `REPO_TYPES`, `DOCSFY_DOCS_URL`, `DOCSFY_REPO_URL` |
+| Data models | `src/docsfy/models.py` | `GenerateRequest`, `DocPlan`, `DocPage`, `NavGroup`, `RepoType` |
 | DB constants & validators | `src/docsfy/storage.py` | `VALID_STATUSES`, `VALID_ROLES`, `_validate_name()`, `_validate_owner()` |
 | Git timeouts | `src/docsfy/repository.py` | `_CLONE_TIMEOUT`, `_FETCH_TIMEOUT`, `_DIFF_TIMEOUT` |
-| Prompt constants | `src/docsfy/prompts.py` | `_MAX_DIFF_LENGTH`, `_GUIDE_WRITING_RULES`, `_REFERENCE_WRITING_RULES`, `_RECIPE_WRITING_RULES`, `_CONCEPT_WRITING_RULES`, `_INCREMENTAL_WRITING_RULES`, `truncate_diff_content()` |
+| Prompt constants | `src/docsfy/prompts.py` | `_MAX_DIFF_LENGTH`, `_GUIDE_WRITING_RULES`, `_REFERENCE_WRITING_RULES`, `_RECIPE_WRITING_RULES`, `_CONCEPT_WRITING_RULES`, `_INCREMENTAL_WRITING_RULES`, `_NAV_STRUCTURE_MAP`, `_REPO_TYPE_WRITING_RULES_MAP`, `truncate_diff_content()` |
 | Frontend constants | `frontend/src/lib/constants.ts` | API base URL, poll intervals, toast durations |
 | Frontend types | `frontend/src/types/index.ts` | `Project`, `User`, `Variant`, `AuthState` |
 | Frontend API client | `frontend/src/lib/api.ts` | `fetchProjects()`, `login()`, `generateDocs()` |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Frontend Builder
-FROM node:20-slim AS frontend-builder
+FROM node:22-slim AS frontend-builder
 
 WORKDIR /app/frontend
 
@@ -12,7 +12,7 @@ COPY frontend/ ./
 RUN npm run build
 
 # Stage 2: Python Builder
-FROM python:3.12-slim AS builder
+FROM python:3.14-slim AS builder
 
 WORKDIR /app
 
@@ -32,7 +32,7 @@ COPY src/ src/
 RUN uv sync --frozen --no-dev
 
 # Stage 3: Runtime
-FROM python:3.12-slim
+FROM python:3.14-slim
 
 WORKDIR /app
 

--- a/frontend/src/components/shared/GenerateForm.tsx
+++ b/frontend/src/components/shared/GenerateForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect } from 'react'
 import { Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -13,15 +13,11 @@ import {
 } from '@/components/ui/select'
 import Combobox from '@/components/shared/Combobox'
 import { api } from '@/lib/api'
-import { TOAST_DEFAULT_MS, TOAST_ERROR_MS, VALID_PROVIDERS } from '@/lib/constants'
+import { SK_REPO, SK_BRANCH, SK_FORCE, SK_REPO_TYPE, TOAST_DEFAULT_MS, TOAST_ERROR_MS, VALID_PROVIDERS, VALID_REPO_TYPES } from '@/lib/constants'
 import type { AvailableModels } from '@/types'
 import { ApiError } from '@/types'
 const DEFAULT_PROVIDER = 'cursor'
 const DEFAULT_BRANCH = 'main'
-
-const SK_REPO = 'docsfy-repo'
-const SK_BRANCH = 'docsfy-branch'
-const SK_FORCE = 'docsfy-force'
 
 interface GenerateFormProps {
   availableModels: AvailableModels
@@ -48,16 +44,8 @@ export default function GenerateForm({
   const [provider, setProvider] = useState<string>(DEFAULT_PROVIDER)
   const [model, setModel] = useState('')
   const [force, setForce] = useState(false)
+  const [repoType, setRepoType] = useState<string>('')
   const [isSubmitting, setIsSubmitting] = useState(false)
-
-  // Determine the default model for a given provider
-  const getDefaultModel = useCallback(
-    (prov: string): string => {
-      const models = availableModels[prov]
-      return models && models.length > 0 ? models[0].id : ''
-    },
-    [availableModels],
-  )
 
   // Restore form state from sessionStorage on mount
   useEffect(() => {
@@ -65,25 +53,13 @@ export default function GenerateForm({
     const savedBranch = sessionStorage.getItem(SK_BRANCH)
     const savedForce = sessionStorage.getItem(SK_FORCE)
 
+    const savedRepoType = sessionStorage.getItem(SK_REPO_TYPE)
+
     if (savedRepo) setRepoUrl(savedRepo)
     if (savedBranch) setBranch(savedBranch)
     if (savedForce === 'true') setForce(true)
+    if (savedRepoType && (VALID_REPO_TYPES as readonly string[]).includes(savedRepoType)) setRepoType(savedRepoType)
   }, [])
-
-  // Set default model when provider or availableModels changes.
-  // When availableModels arrives asynchronously (via API / WebSocket) and the
-  // model field is still empty, this fills it with the first available model
-  // for the current provider.
-  useEffect(() => {
-    const models = availableModels[provider]
-    if (!models || models.length === 0) return
-
-    setModel((prev) => {
-      // Only auto-fill when the field is empty.
-      // Explicit provider switches are handled in handleProviderChange().
-      return prev || models[0].id
-    })
-  }, [provider, availableModels])
 
   function sanitizeRepoUrlForStorage(value: string): string {
     try {
@@ -104,11 +80,13 @@ export default function GenerateForm({
     sessionStorage.removeItem(SK_REPO)
     sessionStorage.removeItem(SK_BRANCH)
     sessionStorage.removeItem(SK_FORCE)
+    sessionStorage.removeItem(SK_REPO_TYPE)
     setRepoUrl('')
     setBranch(DEFAULT_BRANCH)
     setProvider(DEFAULT_PROVIDER)
-    setModel(getDefaultModel(DEFAULT_PROVIDER))
+    setModel('')
     setForce(false)
+    setRepoType('')
   }
 
   function handleRepoChange(value: string) {
@@ -123,11 +101,11 @@ export default function GenerateForm({
 
   function handleProviderChange(value: string) {
     setProvider(value)
-    // Auto-fill model with first model for new provider if current model is not valid
+    // Clear model if current selection is not valid for the new provider
     const models = availableModels[value]
     if (models && models.length > 0) {
       if (!models.some(m => m.id === model)) {
-        setModel(models[0].id)
+        setModel('')
       }
     } else {
       setModel('')
@@ -137,6 +115,17 @@ export default function GenerateForm({
   function handleForceChange(checked: boolean) {
     setForce(checked)
     saveToSession(SK_FORCE, String(checked))
+  }
+
+  function handleRepoTypeChange(value: string | null) {
+    if (!value) return
+    const newType = value === 'auto' ? '' : value
+    setRepoType(newType)
+    if (value !== 'auto') {
+      saveToSession(SK_REPO_TYPE, value)
+    } else {
+      sessionStorage.removeItem(SK_REPO_TYPE)
+    }
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -155,13 +144,19 @@ export default function GenerateForm({
 
     setIsSubmitting(true)
     try {
-      await api.post('/api/generate', {
+      const payload: Record<string, unknown> = {
         repo_url: submittedRepoUrl,
         branch: submittedBranch,
         ai_provider: submittedProvider,
-        ai_model: submittedModel,
         force: submittedForce,
-      })
+      }
+      if (submittedModel) {
+        payload.ai_model = submittedModel
+      }
+      if (repoType) {
+        payload.repo_type = repoType
+      }
+      await api.post('/api/generate', payload)
 
       const projectName = extractRepoName(submittedRepoUrl)
       toast.success(`Generation started for ${projectName}`, {
@@ -217,6 +212,24 @@ export default function GenerateForm({
             disabled={isSubmitting}
             data-testid="branch-input"
           />
+        </div>
+
+        {/* Repository Type */}
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="repo-type-select" title="Type of repository (auto-detected if not specified)">Repository Type</Label>
+          <Select disabled={isSubmitting} value={repoType || 'auto'} onValueChange={handleRepoTypeChange}>
+            <SelectTrigger id="repo-type-select" data-testid="repo-type-select" className="w-full">
+              <SelectValue placeholder="Auto-detect" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="auto">Auto-detect</SelectItem>
+              {VALID_REPO_TYPES.map((t) => (
+                <SelectItem key={t} value={t}>
+                  {t.charAt(0).toUpperCase() + t.slice(1)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
 
         {/* Provider */}

--- a/frontend/src/components/shared/VariantDetail.tsx
+++ b/frontend/src/components/shared/VariantDetail.tsx
@@ -168,6 +168,12 @@ function InfoGrid({ project, isAdmin }: { project: Project; isAdmin: boolean }) 
         <span className="text-muted-foreground">Branch</span>
         <div className="mt-0.5 font-medium">{project.branch}</div>
       </div>
+      {project.repo_type && (
+        <div>
+          <span className="text-muted-foreground">Repo Type</span>
+          <div className="mt-0.5 font-medium capitalize">{project.repo_type}</div>
+        </div>
+      )}
       <div>
         <span className="text-muted-foreground" title="Number of documentation pages generated">Pages</span>
         <div className="mt-0.5 font-medium">{project.page_count}</div>
@@ -298,6 +304,7 @@ function RegenerateSection({
         ai_provider: provider,
         ai_model: model,
         force,
+        ...(project.repo_type ? { repo_type: project.repo_type } : {}),
       })
       toast.success(`Regeneration started for ${project.name}`, { duration: TOAST_DEFAULT_MS })
       onRegenerate?.(provider, model, force)

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,5 +1,7 @@
 export const VALID_PROVIDERS = ['claude', 'gemini', 'cursor'] as const
 
+export const VALID_REPO_TYPES = ['app', 'tests', 'library', 'framework'] as const
+
 export const DOCSFY_DOCS_URL = 'https://myk-org.github.io/docsfy/'
 export const DOCSFY_REPO_URL = 'https://github.com/myk-org/docsfy'
 
@@ -13,6 +15,11 @@ export const WS_HEARTBEAT_INTERVAL_MS = 30000
 export const WS_RECONNECT_MAX_DELAY_MS = 30000
 export const WS_POLLING_FALLBACK_MS = 10000
 export const RELOAD_DELAY_MS = 1000
+
+export const SK_REPO = 'docsfy-repo'
+export const SK_BRANCH = 'docsfy-branch'
+export const SK_FORCE = 'docsfy-force'
+export const SK_REPO_TYPE = 'docsfy-repo-type'
 
 export const TREE_EXPANDED_KEY = 'docsfy-tree-expanded'
 export const SELECTED_VIEW_KEY = 'docsfy-selected-view'

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,6 +1,7 @@
 export type ProjectStatus = 'generating' | 'ready' | 'error' | 'aborted'
 export type UserRole = 'admin' | 'user' | 'viewer'
 export type AIProvider = 'claude' | 'gemini' | 'cursor'
+export type RepoType = 'app' | 'tests' | 'library' | 'framework'
 export type AvailableModels = Record<string, Array<{id: string; name: string}>>
 
 export interface ComboboxOption {
@@ -22,6 +23,7 @@ export interface Project {
   page_count: number
   error_message: string | null
   plan_json: string | null
+  repo_type: RepoType | null
   total_cost_usd: number | null
   generation_id: string | null
   created_at: string
@@ -36,6 +38,7 @@ export interface GenerateRequest {
   ai_cli_timeout?: number
   force?: boolean
   branch?: string
+  repo_type?: RepoType
 }
 
 export interface DocPlan {

--- a/skills/docsfy-generate-docs/SKILL.md
+++ b/skills/docsfy-generate-docs/SKILL.md
@@ -204,11 +204,12 @@ treat it as not configured for Phase 6 purposes.
 Run the generation command using **`Bash(run_in_background=true)`** since it is a long-running blocking operation:
 
 ```bash
-docsfy generate <repo_url> --branch <branch> --provider <provider> --model <model> --watch [--force]
+docsfy generate <repo_url> --branch <branch> --provider <provider> --model <model> --watch [--force] [--repo-type <type>]
 ```
 
 - Always use `--watch` for real-time WebSocket progress
 - Add `--force` only if user requested force regeneration
+- Add `--repo-type <type>` if user specifies the repository type (app, tests, library, framework). If not specified, the AI auto-detects the type.
 - **Use `run_in_background=true`** on the Bash tool so the main conversation is not blocked.
   You will be notified when the command completes.
 
@@ -432,6 +433,7 @@ Display:
 | Command | Purpose |
 |---------|---------|
 | `docsfy generate <url> --watch` | Generate docs with live progress |
+| `docsfy generate <url> --watch --repo-type tests` | Generate docs for a test suite repo |
 | `docsfy status <name>` | Check generation status |
 | `docsfy download <name> -o <dir>` | Download docs to directory |
 | `docsfy list` | List all projects |

--- a/src/docsfy/api/projects.py
+++ b/src/docsfy/api/projects.py
@@ -32,6 +32,7 @@ from docsfy.generator import (
 )
 from docsfy.models import (
     DEFAULT_BRANCH,
+    REPO_TYPES,
     VALID_PROVIDERS,
     GenerateRequest,
     is_uuid,
@@ -126,6 +127,7 @@ async def update_and_notify(
     current_stage: str | None | object = None,
     generation_id: str | None = None,
     total_cost_usd: float | None = None,
+    repo_type: str | None = None,
 ) -> None:
     """Update project status in DB and send WebSocket notification."""
     ups_kwargs: dict[str, Any] = {
@@ -144,6 +146,8 @@ async def update_and_notify(
         ups_kwargs["plan_json"] = plan_json
     if total_cost_usd is not None:
         ups_kwargs["total_cost_usd"] = total_cost_usd
+    if repo_type is not None:
+        ups_kwargs["repo_type"] = repo_type
 
     # Always pass current_stage through so that None clears the stage in the DB.
     ups_kwargs["current_stage"] = current_stage
@@ -551,6 +555,7 @@ async def _run_generation(
     owner: str = "",
     branch: str = DEFAULT_BRANCH,
     generation_id: str | None = None,
+    repo_type: str | None = None,
 ) -> None:
     gen_key = f"{owner}/{project_name}/{branch}/{ai_provider}/{ai_model}"
     cost_acc = CostAccumulator()
@@ -603,6 +608,7 @@ async def _run_generation(
                 owner,
                 branch=branch,
                 generation_id=generation_id,
+                repo_type=repo_type,
             )
         else:
             # Remote repository - clone to temp dir
@@ -625,6 +631,7 @@ async def _run_generation(
                     owner,
                     branch=branch,
                     generation_id=generation_id,
+                    repo_type=repo_type,
                 )
 
     except asyncio.CancelledError:
@@ -696,6 +703,7 @@ async def _generate_from_path(
     owner: str = "",
     branch: str = DEFAULT_BRANCH,
     generation_id: str | None = None,
+    repo_type: str | None = None,
 ) -> None:
     cache_dir = get_project_cache_dir(
         project_name, ai_provider, ai_model, owner, branch=branch
@@ -725,6 +733,11 @@ async def _generate_from_path(
             if base_project and base_project.get("plan_json") is not None
             else None
         )
+        base_repo_type = (
+            str(base_project["repo_type"])
+            if base_project and base_project.get("repo_type") is not None
+            else None
+        )
         await update_and_notify(
             gen_key,
             project_name,
@@ -738,6 +751,7 @@ async def _generate_from_path(
             page_count=page_count,
             plan_json=plan_json,
             generation_id=generation_id,
+            repo_type=base_repo_type,
         )
 
     async def _replace_base_variant() -> None:
@@ -983,11 +997,23 @@ async def _generate_from_path(
             ai_provider=ai_provider,
             ai_model=ai_model,
             ai_cli_timeout=ai_cli_timeout,
+            repo_type=repo_type,
         )
 
     if plan is None:
         raise RuntimeError("Plan was not generated")
     plan["repo_url"] = source_url
+
+    # Extract auto-detected or provided repo_type from plan
+    detected_repo_type = repo_type or plan.get("repo_type", "app")
+    if detected_repo_type not in REPO_TYPES:
+        logger.warning(
+            f"[{project_name}] Planner returned unknown repo_type "
+            f"'{detected_repo_type}', defaulting to 'app'"
+        )
+        detected_repo_type = "app"
+
+    plan["repo_type"] = detected_repo_type
 
     if not use_cache and cache_dir.exists():
         # A full regeneration should start from a clean cache so progress reflects
@@ -1012,6 +1038,7 @@ async def _generate_from_path(
         plan_json=json.dumps(plan),
         page_count=current_page_count,
         generation_id=generation_id,
+        repo_type=detected_repo_type,
     )
 
     async def _on_page_generated(page_count: int) -> None:
@@ -1038,6 +1065,7 @@ async def _generate_from_path(
         diff_content=diff_content,
         branch=branch,
         on_page_generated=_on_page_generated,
+        repo_type=detected_repo_type,
     )
 
     # --- Post-generation pipeline ---
@@ -1384,6 +1412,7 @@ async def generate(
 
     # Fix 6: Use lock to prevent race condition between check and add
     branch = gen_request.branch
+    repo_type = gen_request.repo_type
     gen_key = f"{owner}/{project_name}/{branch}/{ai_provider}/{ai_model}"
     async with _gen_lock:
         if gen_key in _generating:
@@ -1400,6 +1429,7 @@ async def generate(
             ai_model=ai_model,
             owner=owner,
             branch=branch,
+            repo_type=repo_type,
         )
 
         try:
@@ -1416,6 +1446,7 @@ async def generate(
                     owner=owner,
                     branch=branch,
                     generation_id=gen_id,
+                    repo_type=repo_type,
                 )
             )
             _generating[gen_key] = task
@@ -1428,6 +1459,7 @@ async def generate(
         "status": "generating",
         "branch": branch,
         "generation_id": gen_id,
+        "repo_type": repo_type,
     }
 
 

--- a/src/docsfy/cli/generate.py
+++ b/src/docsfy/cli/generate.py
@@ -141,6 +141,12 @@ def generate(
         None, "--provider", help="AI provider (claude, gemini, cursor)"
     ),
     model: Optional[str] = typer.Option(None, "--model", "-m", help="AI model name"),  # noqa: M511
+    repo_type: Optional[str] = typer.Option(  # noqa: M511
+        None,
+        "--repo-type",
+        "-t",
+        help="Repository type (app, tests, library, framework). Auto-detected if not specified.",
+    ),
     force: bool = typer.Option(False, "--force", "-f", help="Force full regeneration"),  # noqa: M511
     watch: bool = typer.Option(  # noqa: M511
         False, "--watch", "-w", help="Watch generation progress via WebSocket"
@@ -148,6 +154,15 @@ def generate(
 ) -> None:
     """Generate documentation for a Git repository."""
     from docsfy.cli.main import _state, get_client
+
+    from docsfy.models import REPO_TYPES
+
+    if repo_type and repo_type not in REPO_TYPES:
+        typer.echo(
+            f"Invalid repo type: '{repo_type}'. Must be one of: {', '.join(REPO_TYPES)}",
+            err=True,
+        )
+        raise typer.Exit(code=1)
 
     client = get_client()
     try:
@@ -160,6 +175,8 @@ def generate(
             payload["ai_provider"] = provider
         if model:
             payload["ai_model"] = model
+        if repo_type:
+            payload["repo_type"] = repo_type
 
         response = client.post("/api/generate", json=payload)
         data = response.json()
@@ -170,6 +187,8 @@ def generate(
 
         typer.echo(f"Project: {project_name}")
         typer.echo(f"Branch: {result_branch}")
+        if repo_type:
+            typer.echo(f"Repo Type: {repo_type}")
         typer.echo(f"Status: {status}")
         if gen_id:
             typer.echo(f"Generation ID: {gen_id}")

--- a/src/docsfy/generator.py
+++ b/src/docsfy/generator.py
@@ -213,6 +213,7 @@ async def generate_full_page_content(
     exclusions_path: str | None = None,
     page_type: str = "guide",
     other_pages_path: str | None = None,
+    repo_type: str = "app",
 ) -> str:
     prompt = build_page_prompt(
         project_name=project_name,
@@ -221,6 +222,7 @@ async def generate_full_page_content(
         page_type=page_type,
         exclusions_path=exclusions_path,
         other_pages_path=other_pages_path,
+        repo_type=repo_type,
     )
     output = await _call_ai_or_raise(
         prompt=prompt,
@@ -244,6 +246,7 @@ async def _generate_incremental_page_content(
     ai_model: str,
     ai_cli_timeout: int | None = None,
     page_type: str = "guide",
+    repo_type: str = "app",
 ) -> str:
     job_dir = Path(tempfile.mkdtemp(prefix="docsfy-incremental-page-"))
     try:
@@ -262,6 +265,7 @@ async def _generate_incremental_page_content(
             changed_files=changed_files,
             diff_path=str(diff_file),
             page_type=page_type,
+            repo_type=repo_type,
         )
         output = await _call_ai_or_raise(
             prompt=prompt,
@@ -281,9 +285,10 @@ async def run_planner(
     ai_provider: str,
     ai_model: str,
     ai_cli_timeout: int | None = None,
+    repo_type: str | None = None,
 ) -> dict[str, Any]:
     logger.info(f"[{project_name}] Calling AI planner")
-    prompt = build_planner_prompt(project_name)
+    prompt = build_planner_prompt(project_name, repo_type=repo_type)
     output = await _call_ai_or_raise(
         prompt=prompt,
         repo_path=repo_path,
@@ -339,6 +344,7 @@ async def generate_page(
     on_page_generated: Callable[[int], Awaitable[None]] | None = None,
     page_type: str = "guide",
     other_pages_path: str | None = None,
+    repo_type: str = "app",
 ) -> str:
     _label = project_name or repo_path.name
     prompt_project_name = project_name or repo_path.name
@@ -371,6 +377,7 @@ async def generate_page(
                     ai_model=ai_model,
                     ai_cli_timeout=ai_cli_timeout,
                     page_type=page_type,
+                    repo_type=repo_type,
                 )
             except (RuntimeError, ValueError) as exc:
                 logger.warning(
@@ -387,6 +394,7 @@ async def generate_page(
                     ai_cli_timeout=ai_cli_timeout,
                     page_type=page_type,
                     other_pages_path=other_pages_path,
+                    repo_type=repo_type,
                 )
         else:
             output = await generate_full_page_content(
@@ -399,6 +407,7 @@ async def generate_page(
                 ai_cli_timeout=ai_cli_timeout,
                 page_type=page_type,
                 other_pages_path=other_pages_path,
+                repo_type=repo_type,
             )
     except RuntimeError as exc:
         logger.warning(f"[{_label}] Failed to generate page '{slug}': {exc}")
@@ -448,6 +457,7 @@ async def generate_all_pages(
     diff_content: str | None = None,
     branch: str = DEFAULT_BRANCH,
     on_page_generated: Callable[[int], Awaitable[None]] | None = None,
+    repo_type: str = "app",
 ) -> dict[str, str]:
     _label = project_name or repo_path.name
 
@@ -511,6 +521,7 @@ async def generate_all_pages(
                 branch=branch,
                 on_page_generated=on_page_generated,
                 other_pages_path=str(pages_manifest_path),
+                repo_type=repo_type,
             )
             for p in all_pages
         ]

--- a/src/docsfy/models.py
+++ b/src/docsfy/models.py
@@ -14,6 +14,9 @@ DEFAULT_BRANCH = "main"
 DOCSFY_DOCS_URL = "https://myk-org.github.io/docsfy/"
 DOCSFY_REPO_URL = "https://github.com/myk-org/docsfy"
 
+RepoType = Literal["app", "tests", "library", "framework"]
+REPO_TYPES: tuple[str, ...] = get_args(RepoType)
+
 
 class GenerateRequest(BaseModel):
     repo_url: str | None = Field(
@@ -25,6 +28,9 @@ class GenerateRequest(BaseModel):
     ai_cli_timeout: int | None = Field(default=None, gt=0)
     force: bool = Field(
         default=False, description="Force full regeneration, ignoring cache"
+    )
+    repo_type: RepoType | None = Field(
+        default=None, description="Repository type (auto-detected if not specified)"
     )
     branch: str = Field(
         default=DEFAULT_BRANCH, description="Git branch to generate docs from"
@@ -115,8 +121,19 @@ class NavGroup(BaseModel):
 class DocPlan(BaseModel):
     project_name: str
     tagline: str = ""
+    repo_type: RepoType = "app"
     navigation: list[NavGroup] = Field(default_factory=list)
     version: str | None = None
+
+    @field_validator("repo_type", mode="before")
+    @classmethod
+    def normalize_repo_type(cls, v: Any) -> Any:
+        if not isinstance(v, str):
+            return "app"
+        v = v.strip().lower()
+        if v not in REPO_TYPES:
+            return "app"
+        return v
 
 
 def is_uuid(value: str) -> bool:

--- a/src/docsfy/prompts.py
+++ b/src/docsfy/prompts.py
@@ -2,16 +2,20 @@ from __future__ import annotations
 
 from simple_logger.logger import get_logger
 
-from docsfy.models import PAGE_TYPES
+from docsfy.models import PAGE_TYPES, REPO_TYPES
 
 logger = get_logger(name=__name__)
 
 _PAGE_TYPE_VALUES = ", ".join(PAGE_TYPES)
+_REPO_TYPE_VALUES = ", ".join(REPO_TYPES)
 
 PLAN_SCHEMA = (
     """{
   "project_name": "string - project name",
   "tagline": "string - one-line project description (what it does for the user, not what it is)",
+  "repo_type": "string - one of: """
+    + _REPO_TYPE_VALUES
+    + """",
   "navigation": [
     {
       "group": "string - section group name",
@@ -30,16 +34,7 @@ PLAN_SCHEMA = (
 }"""
 )
 
-
-def build_planner_prompt(project_name: str) -> str:
-    return f"""You are a documentation planner focused on the USER EXPERIENCE. Explore this repository thoroughly.
-Read source code, configuration files, tests, CI/CD pipelines, and project structure.
-Do NOT rely on the README — understand the project from its code and configuration.
-
-Then create a documentation plan as a JSON object. The plan must be structured as a USER JOURNEY,
-not an architecture tour. Think: "What does a new user need to do first? Then what?"
-
-NAVIGATION STRUCTURE (use these groups in order, skip any that don't apply):
+_NAV_STRUCTURE_APP = """NAVIGATION STRUCTURE (use these groups in order, skip any that don't apply):
 
 1. "Getting Started" — Installation, prerequisites, quickstart. Get the user productive in 60 seconds.
    Page types: guide
@@ -60,7 +55,137 @@ NAVIGATION STRUCTURE (use these groups in order, skip any that don't apply):
 
 5. "Internals" — Architecture, data model, internal design. ONLY if the project is a framework/library
    where users genuinely need to understand internals to use it effectively. Skip for most tools/apps.
+   Page types: concept"""
+
+_NAV_STRUCTURE_TESTS = """NAVIGATION STRUCTURE (use these groups in order, skip any that don't apply):
+
+1. "Getting Started" — Prerequisites, environment setup, how to run the test suite, container-based execution.
+   Page types: guide
+
+2. "Test Domains" — One page per major functional domain (e.g., virtualization tests, network tests, storage tests).
+   Each page should cover: purpose, sub-areas, key test files, required fixtures, markers, and configuration.
+   Page types: guide
+
+3. "Framework & Patterns" — Shared testing patterns, fixture hierarchy and scoping strategy,
+   parameterization schemes, resource lifecycle management (setup/teardown), validation utilities.
+   Include source file references (paths) so developers can navigate to implementations.
    Page types: concept
+
+4. "Writing Tests" — How to add new tests, how to use shared fixtures, naming conventions,
+   how to add new test domains, common pitfalls.
+   Page types: guide
+
+5. "Utilities Reference" — Organized reference of utility modules with function tables.
+   Each entry should include: function name, purpose, file path, and key parameters.
+   Page types: reference
+
+6. "Development Workflow" — Code quality tooling, CI/CD pipeline, pre-commit hooks, container builds,
+   dependency management, linting and type checking.
+   Page types: guide
+
+7. "Advanced Topics" — Cross-component testing, scale/performance testing, upgrade/lifecycle testing,
+   multi-environment setup, specialized configurations.
+   Page types: concept"""
+
+_NAV_STRUCTURE_LIBRARY = """NAVIGATION STRUCTURE (use these groups in order, skip any that don't apply):
+
+1. "Getting Started" — Installation, quick start, minimal working example. Get the developer productive fast.
+   Page types: guide
+
+2. "User Guides" — Task-oriented pages for common use cases. Each page answers "How do I do X?"
+   Page types: guide
+
+3. "API Reference" — Complete public API documentation. Every public class, function, and method.
+   Include signatures, parameter types, return types, and examples.
+   Page types: reference
+
+4. "Architecture" — Internal design, data flow, key abstractions. How the library is structured
+   and why. Include component relationship diagrams (text-based).
+   Page types: concept
+
+5. "Recipes" — Copy-paste-ready code patterns for common integrations and use cases.
+   Page types: recipe
+
+6. "Advanced Usage" — Extension points, customization, plugin development, performance tuning.
+   Page types: guide"""
+
+_NAV_STRUCTURE_FRAMEWORK = """NAVIGATION STRUCTURE (use these groups in order, skip any that don't apply):
+
+1. "Getting Started" — Installation, scaffolding, hello-world project. Get a minimal app running.
+   Page types: guide
+
+2. "Core Concepts" — Framework lifecycle, request/response flow, middleware pipeline,
+   dependency injection, configuration system. The mental model for the framework.
+   Page types: concept
+
+3. "User Guides" — Building features with the framework. Each page covers one area:
+   routing, templates, database, authentication, etc.
+   Page types: guide
+
+4. "Plugin & Extension Development" — How to write plugins, hooks, custom middleware,
+   lifecycle events, extension points, registry system.
+   Page types: guide
+
+5. "API Reference" — Complete public API. Classes, decorators, configuration options,
+   CLI commands, environment variables.
+   Page types: reference
+
+6. "Recipes" — Common patterns and integrations. Deployment recipes, testing recipes,
+   database patterns, caching strategies.
+   Page types: recipe
+
+7. "Internals" — Architecture deep dives for contributors. Source code organization,
+   build system, contribution workflow.
+   Page types: concept"""
+
+_NAV_STRUCTURE_MAP: dict[str, str] = {
+    "app": _NAV_STRUCTURE_APP,
+    "tests": _NAV_STRUCTURE_TESTS,
+    "library": _NAV_STRUCTURE_LIBRARY,
+    "framework": _NAV_STRUCTURE_FRAMEWORK,
+}
+
+# "app" is the default fallback, so the map must cover all repo types
+if set(_NAV_STRUCTURE_MAP) != set(REPO_TYPES):
+    _missing_nav = set(REPO_TYPES) - set(_NAV_STRUCTURE_MAP)
+    raise RuntimeError(
+        f"Navigation structure must cover all repo types: {_missing_nav} missing"
+    )
+
+
+def _get_navigation_structure(repo_type: str | None) -> str:
+    """Return type-specific navigation structure instructions."""
+    if repo_type is None or repo_type not in _NAV_STRUCTURE_MAP:
+        return _NAV_STRUCTURE_MAP["app"]
+    return _NAV_STRUCTURE_MAP[repo_type]
+
+
+def build_planner_prompt(project_name: str, repo_type: str | None = None) -> str:
+    if repo_type is not None:
+        repo_type_block = f"""Repository type: {repo_type}
+Include the repo type in your response as "repo_type": "{repo_type}"."""
+    else:
+        repo_type_block = """REPO TYPE DETECTION:
+First, analyze the repository to determine its type:
+- "app" — A tool, service, or application that end users interact with directly
+- "tests" — A test suite or test framework (look for: pytest fixtures, test runners, conftest.py, test directories)
+- "library" — A reusable package/module with a public API (look for: published package, API exports, __init__.py with public classes)
+- "framework" — An extensible platform with plugin/hook systems (look for: plugin registries, lifecycle hooks, abstract base classes for extension)
+
+Include the detected type in your response as "repo_type": "<type>"."""
+
+    nav_structure = _get_navigation_structure(repo_type)
+
+    return f"""You are a documentation planner focused on the USER EXPERIENCE. Explore this repository thoroughly.
+Read source code, configuration files, tests, CI/CD pipelines, and project structure.
+Do NOT rely on the README — understand the project from its code and configuration.
+
+Then create a documentation plan as a JSON object. The plan must be structured as a USER JOURNEY,
+not an architecture tour. Think: "What does a new user need to do first? Then what?"
+
+{repo_type_block}
+
+{nav_structure}
 
 CRITICAL RULES:
 - Do NOT create an "Introduction" or "Overview" page — fold that into the Getting Started quickstart page
@@ -233,6 +358,57 @@ def _get_writing_rules(page_type: str) -> str:
     return _WRITING_RULES_MAP[page_type]
 
 
+_REPO_TYPE_RULES_TESTS = """
+REPO TYPE RULES (test suite):
+- Include source file paths (e.g., `tests/virt/conftest.py`) when referencing test files, fixtures, or utilities.
+- Document fixture scoping (session, module, class, function) and explain lifecycle implications.
+- Show pytest markers and their effects on test collection and execution.
+- Include function/class tables mapping names to purposes and file locations.
+- Document shared patterns with concrete code examples from the actual test suite."""
+
+_REPO_TYPE_RULES_LIBRARY = """
+REPO TYPE RULES (library):
+- Document the public API surface — every public class, function, and constant.
+- Include type signatures, parameter descriptions, return types, and concrete examples.
+- Show import paths so developers know how to access each component.
+- Document exceptions and error handling for each public function."""
+
+_REPO_TYPE_RULES_FRAMEWORK = """
+REPO TYPE RULES (framework):
+- Document extension points and hook signatures.
+- Show the lifecycle flow and where hooks/middleware execute.
+- Include both "using" and "extending" perspectives for each feature.
+- Document configuration options with defaults, types, and effects."""
+
+_REPO_TYPE_WRITING_RULES_MAP: dict[str, str] = {
+    "tests": _REPO_TYPE_RULES_TESTS,
+    "library": _REPO_TYPE_RULES_LIBRARY,
+    "framework": _REPO_TYPE_RULES_FRAMEWORK,
+}
+
+# "app" has no extra writing rules — only non-app types need entries
+_EXPECTED_REPO_TYPE_RULES = set(REPO_TYPES) - {"app"}
+if set(_REPO_TYPE_WRITING_RULES_MAP) != _EXPECTED_REPO_TYPE_RULES:
+    _missing_rt = _EXPECTED_REPO_TYPE_RULES - set(_REPO_TYPE_WRITING_RULES_MAP)
+    raise RuntimeError(
+        f"Repo-type writing rules must cover all non-app repo types: {_missing_rt} missing"
+    )
+
+# Page types that receive repo-type-specific rules
+_REPO_TYPE_APPLICABLE_PAGE_TYPES = {"guide", "concept", "reference"}
+
+
+def _get_repo_type_writing_rules(page_type: str, repo_type: str = "app") -> str:
+    """Return combined writing rules for a page type and repo type."""
+    base_rules = _get_writing_rules(page_type)
+    if (
+        repo_type in _REPO_TYPE_WRITING_RULES_MAP
+        and page_type in _REPO_TYPE_APPLICABLE_PAGE_TYPES
+    ):
+        return base_rules + _REPO_TYPE_WRITING_RULES_MAP[repo_type]
+    return base_rules
+
+
 _INCREMENTAL_WRITING_RULES: dict[str, str] = {
     "guide": "Match the page's existing tone. For new_text: lead with examples, use short paragraphs, prefer bullet lists and numbered steps, avoid internal implementation details.",
     "reference": "Match the page's existing tone. For new_text: be precise and scannable, use tables for parameters, include code examples, avoid narrative explanations.",
@@ -254,6 +430,30 @@ def _get_incremental_writing_rules(page_type: str) -> str:
         )
         page_type = "guide"
     return _INCREMENTAL_WRITING_RULES[page_type]
+
+
+_INCREMENTAL_REPO_TYPE_RULES: dict[str, str] = {
+    "tests": "Include source file paths when referencing tests/fixtures. Document fixture scoping and pytest markers. Use function/class tables.",
+    "library": "Document public API surface with type signatures and import paths. Document exceptions and error handling.",
+    "framework": "Document extension points and hook signatures. Show lifecycle flow. Include using and extending perspectives.",
+}
+
+if set(_INCREMENTAL_REPO_TYPE_RULES) != _EXPECTED_REPO_TYPE_RULES:
+    _missing_inc_rt = _EXPECTED_REPO_TYPE_RULES - set(_INCREMENTAL_REPO_TYPE_RULES)
+    raise RuntimeError(
+        f"Incremental repo-type rules must cover all non-app repo types: {_missing_inc_rt} missing"
+    )
+
+
+def _get_incremental_repo_type_rules(page_type: str, repo_type: str = "app") -> str:
+    """Return combined incremental writing rules for a page type and repo type."""
+    base_rules = _get_incremental_writing_rules(page_type)
+    if (
+        repo_type in _INCREMENTAL_REPO_TYPE_RULES
+        and page_type in _REPO_TYPE_APPLICABLE_PAGE_TYPES
+    ):
+        return base_rules + " " + _INCREMENTAL_REPO_TYPE_RULES[repo_type]
+    return base_rules
 
 
 INCREMENTAL_PAGE_UPDATE_SCHEMA = """{
@@ -283,6 +483,20 @@ def truncate_diff_content(diff_content: str, max_chars: int = _MAX_DIFF_LENGTH) 
     )
 
 
+_AUDIENCE_MAP: dict[str, str] = {
+    "app": "end users of the project",
+    "tests": "test developers and contributors working with the test suite",
+    "library": "developers integrating this library into their projects",
+    "framework": "developers building applications with this framework",
+}
+
+if set(_AUDIENCE_MAP) != set(REPO_TYPES):
+    _missing_aud = set(REPO_TYPES) - set(_AUDIENCE_MAP)
+    raise RuntimeError(
+        f"Audience map must cover all repo types: {_missing_aud} missing"
+    )
+
+
 def build_page_prompt(
     project_name: str,
     page_title: str,
@@ -290,8 +504,9 @@ def build_page_prompt(
     page_type: str = "guide",
     exclusions_path: str | None = None,
     other_pages_path: str | None = None,
+    repo_type: str = "app",
 ) -> str:
-    writing_rules = _get_writing_rules(page_type)
+    writing_rules = _get_repo_type_writing_rules(page_type, repo_type)
     exclusions_block = ""
     if exclusions_path:
         exclusions_block = f"""
@@ -314,6 +529,8 @@ When referencing another page, ALWAYS use a markdown link with the exact slug fr
   See [Page Title](page-slug.html) for details.
 Do NOT write plain text like "See Page Title" \u2014 always make it a clickable link."""
 
+    audience = _AUDIENCE_MAP.get(repo_type, _AUDIENCE_MAP["app"])
+
     return f"""You are a technical documentation writer. Explore this repository to write
 the "{page_title}" page for the {project_name} documentation.
 
@@ -328,7 +545,7 @@ to write accurate documentation based on the actual code. Do NOT rely on the REA
 ANTI-REDUNDANCY: This page should OWN its topic exclusively. Do NOT duplicate content
 that belongs on other pages. Instead, link to them: "See [Page Title](page-slug.html)".
 
-This documentation will be read by end users of the project. Separate llms.txt files
+This documentation will be read by {audience}. Separate llms.txt files
 are generated for AI consumption.{exclusions_block}{pages_block}
 
 Start the page with exactly this first line:
@@ -345,6 +562,7 @@ def build_incremental_page_prompt(
     changed_files: list[str],
     diff_path: str,
     page_type: str = "guide",
+    repo_type: str = "app",
 ) -> str:
     return f"""You are a technical documentation writer. The repository "{project_name}" has been updated.
 Your task is to update the existing "{page_title}" documentation page by editing ONLY the relevant sections.
@@ -391,7 +609,7 @@ Instructions:
 - Do NOT add explanations, comments, markdown fences, or any text outside the JSON object
 
 When writing "new_text", follow these content rules:
-{_get_incremental_writing_rules(page_type)}
+{_get_incremental_repo_type_rules(page_type, repo_type)}
 {_CALLOUT_FORMATS}
 {_NO_HTML_DETAILS}
 {_NO_MERMAID_DIAGRAMS}"""

--- a/src/docsfy/storage.py
+++ b/src/docsfy/storage.py
@@ -77,6 +77,7 @@ async def init_db(data_dir: str = "") -> None:
                 page_count INTEGER DEFAULT 0,
                 error_message TEXT,
                 plan_json TEXT,
+                repo_type TEXT,
                 total_cost_usd REAL,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -148,6 +149,7 @@ async def init_db(data_dir: str = "") -> None:
                     page_count INTEGER DEFAULT 0,
                     error_message TEXT,
                     plan_json TEXT,
+                    repo_type TEXT,
                     total_cost_usd REAL,
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -196,6 +198,9 @@ async def init_db(data_dir: str = "") -> None:
             select_cols.append("error_message")
             select_cols.append("plan_json")
             select_cols.append(
+                "repo_type" if "repo_type" in old_columns else "NULL AS repo_type"
+            )
+            select_cols.append(
                 "total_cost_usd"
                 if "total_cost_usd" in old_columns
                 else "NULL AS total_cost_usd"
@@ -207,7 +212,7 @@ async def init_db(data_dir: str = "") -> None:
                 INSERT OR IGNORE INTO projects_new
                     (name, branch, ai_provider, ai_model, owner, generation_id, repo_url, status, current_stage,
                      last_commit_sha, last_generated, page_count, error_message,
-                     plan_json, total_cost_usd, created_at, updated_at)
+                     plan_json, repo_type, total_cost_usd, created_at, updated_at)
                 SELECT {", ".join(select_cols)}
                 FROM projects
             """)
@@ -231,6 +236,15 @@ async def init_db(data_dir: str = "") -> None:
         except sqlite3.OperationalError as exc:
             if "duplicate column name" not in str(exc).lower():
                 logger.exception("Migration failed while adding generation_id column")
+                raise
+
+        # Migration: add repo_type column
+        try:
+            await db.execute("ALTER TABLE projects ADD COLUMN repo_type TEXT")
+            await db.commit()
+        except sqlite3.OperationalError as exc:
+            if "duplicate column name" not in str(exc).lower():
+                logger.exception("Migration failed while adding repo_type column")
                 raise
 
         # Backfill generation_id for existing rows
@@ -347,6 +361,7 @@ async def save_project(
     owner: str = "",
     branch: str = DEFAULT_BRANCH,
     generation_id: str | None = None,
+    repo_type: str | None = None,
 ) -> str:
     """Save or update a project variant. Returns the generation_id."""
     if status not in VALID_STATUSES:
@@ -358,12 +373,13 @@ async def save_project(
         final_gen_id = generation_id or str(uuid.uuid4())
 
         await db.execute(
-            """INSERT INTO projects (name, branch, ai_provider, ai_model, owner, generation_id, repo_url, status, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            """INSERT INTO projects (name, branch, ai_provider, ai_model, owner, generation_id, repo_url, status, repo_type, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
                ON CONFLICT(name, branch, ai_provider, ai_model, owner) DO UPDATE SET
                repo_url = excluded.repo_url,
                status = excluded.status,
                generation_id = COALESCE(projects.generation_id, excluded.generation_id),
+               repo_type = COALESCE(excluded.repo_type, projects.repo_type),
                error_message = NULL,
                current_stage = NULL,
                total_cost_usd = NULL,
@@ -377,6 +393,7 @@ async def save_project(
                 final_gen_id,
                 repo_url,
                 status,
+                repo_type,
             ),
         )
         await db.commit()
@@ -406,6 +423,7 @@ async def update_project_status(
     plan_json: str | None = None,
     current_stage: str | None | object = _UNSET,
     total_cost_usd: float | None = None,
+    repo_type: str | None = None,
 ) -> None:
     if status not in VALID_STATUSES:
         msg = f"Invalid project status: '{status}'. Valid: {', '.join(sorted(VALID_STATUSES))}"
@@ -431,6 +449,9 @@ async def update_project_status(
         if total_cost_usd is not None:
             fields.append("total_cost_usd = ?")
             values.append(total_cost_usd)
+        if repo_type is not None:
+            fields.append("repo_type = ?")
+            values.append(repo_type)
         if status == "ready":
             fields.append("last_generated = CURRENT_TIMESTAMP")
         values.append(name)

--- a/test-plans/e2e-15-repo-type.md
+++ b/test-plans/e2e-15-repo-type.md
@@ -1,0 +1,173 @@
+# E2E Tests: Repository Type Support
+
+> Back to the [main E2E index](e2e-ui-test-plan.md#test-files). Shared execution rules, prerequisites, variables, and environment constraints live there.
+
+---
+
+## Test 30: Repo Type API Validation
+
+**Precondition:** Logged in as `testuser-e2e`.
+
+### 30.1 Generate with explicit repo_type
+
+**Commands:**
+
+```shell
+agent-browser javascript "fetch('/api/generate', {method:'POST', headers:{'Content-Type':'application/json'}, credentials:'same-origin', body: JSON.stringify({repo_url:'https://github.com/myk-org/for-testing-only', branch:'main', repo_type:'tests', ai_provider:'cursor', ai_model:'gpt-5.4-xhigh-fast'})}).then(r=>r.json().then(body=>({status:r.status,body})))"
+```
+
+**Expected result:**
+- Response status 202
+- Response includes `"repo_type": "tests"`
+
+---
+
+### 30.2 Generate with invalid repo_type
+
+**Commands:**
+
+```shell
+agent-browser javascript "fetch('/api/generate', {method:'POST', headers:{'Content-Type':'application/json'}, credentials:'same-origin', body: JSON.stringify({repo_url:'https://github.com/myk-org/for-testing-only', branch:'main', repo_type:'invalid', ai_provider:'cursor', ai_model:'gpt-5.4-xhigh-fast'})}).then(r=>r.json().then(body=>({status:r.status,body})))"
+```
+
+**Expected result:**
+- Response status 422 (Pydantic validation error)
+- Error detail mentions invalid repo_type value
+
+---
+
+### 30.3 Generate with auto-detect (no repo_type)
+
+**Commands:**
+
+```shell
+agent-browser javascript "fetch('/api/generate', {method:'POST', headers:{'Content-Type':'application/json'}, credentials:'same-origin', body: JSON.stringify({repo_url:'https://github.com/myk-org/for-testing-only', branch:'main', ai_provider:'cursor', ai_model:'gpt-5.4-xhigh-fast'})}).then(r=>r.json().then(body=>({status:r.status,body})))"
+```
+
+**Expected result:**
+- Response status 202
+- Response includes `"repo_type": null`
+
+---
+
+## Test 31: Repo Type UI Elements
+
+**Precondition:** Logged in as `testuser-e2e`.
+
+### 31.1 Verify repo type dropdown exists on generate form
+
+**Commands:**
+
+```shell
+agent-browser navigate http://localhost:8800/
+agent-browser screenshot
+```
+
+**Expected result:**
+- Generate form shows "Repository Type" label with a dropdown selector
+- Default value shows "Auto-detect"
+
+---
+
+### 31.2 Verify repo type dropdown options
+
+**Commands:**
+
+```shell
+agent-browser click "[data-testid='repo-type-select']"
+agent-browser screenshot
+```
+
+**Expected result:**
+- Dropdown contains 5 options: Auto-detect, App, Tests, Library, Framework
+
+---
+
+### 31.3 Select a repo type and verify session persistence
+
+**Commands:**
+
+```shell
+agent-browser navigate http://localhost:8800/
+agent-browser click "[data-testid='repo-type-select']"
+agent-browser wait 500
+agent-browser click "[data-value='tests']"
+agent-browser wait 500
+agent-browser javascript "sessionStorage.getItem('docsfy-repo-type')"
+```
+
+**Expected result:**
+- sessionStorage returns `"tests"`
+
+---
+
+### 31.4 Verify repo type display in variant detail
+
+**Precondition:** A generation has completed with an explicit `repo_type` (from Test 30.1 or other).
+
+**Commands:**
+
+```shell
+agent-browser navigate http://localhost:8800/
+agent-browser wait 1000
+agent-browser snapshot -i
+```
+
+From the snapshot, click the `for-testing-only` project to expand it, then click the ready variant under it:
+
+```shell
+agent-browser wait 1000
+agent-browser snapshot -i
+agent-browser screenshot
+```
+
+**Expected result:**
+- Variant detail shows "Repo Type" field with the detected/specified type (e.g., "Tests")
+- Value is capitalized (CSS `capitalize`)
+
+---
+
+## Test 32: Repo Type CLI
+
+### 32.1 CLI generate with --repo-type flag
+
+**Commands:**
+
+```shell
+docsfy generate https://github.com/myk-org/for-testing-only --repo-type tests --branch main
+```
+
+**Expected result:**
+- Output includes `Repo Type: tests`
+- Generation starts successfully
+
+---
+
+### 32.2 CLI generate with invalid --repo-type
+
+**Commands:**
+
+```shell
+set +e
+docsfy generate https://github.com/myk-org/for-testing-only --repo-type invalid --branch main
+echo "exit_code=$?"
+set -e
+```
+
+**Expected result:**
+- Error message: `Invalid repo type: 'invalid'. Must be one of: app, tests, library, framework`
+- Exit code 1
+
+---
+
+### 32.3 CLI generate without --repo-type
+
+**Commands:**
+
+```shell
+docsfy generate https://github.com/myk-org/for-testing-only --branch main
+```
+
+**Expected result:**
+- No "Repo Type" line in output (auto-detect mode)
+- Generation starts successfully

--- a/test-plans/e2e-ui-test-plan.md
+++ b/test-plans/e2e-ui-test-plan.md
@@ -165,6 +165,7 @@ Each linked sub-file contains only the detailed test bodies for its assigned sec
 | [e2e-12-cli.md](e2e-12-cli.md) | 24 | CLI Commands (config, generate, list, status, admin) |
 | [e2e-13-post-generation-pipeline.md](e2e-13-post-generation-pipeline.md) | 27 | Post-Generation Pipeline (version footer, related pages, validation/cross-linking stages, performance) |
 | [e2e-14-models-command.md](e2e-14-models-command.md) | 28 | Models Command (CLI providers/models listing, JSON output, API endpoint, available_models) |
+| [e2e-15-repo-type.md](e2e-15-repo-type.md) | 30-32 | Repository type support (API, UI, CLI) |
 | [e2e-09-cleanup.md](e2e-09-cleanup.md) | 21 | Cleanup and Teardown |
 
 **`e2e-09-cleanup.md` must always be executed last, after all other test files.**
@@ -203,6 +204,9 @@ Each linked sub-file contains only the detailed test bodies for its assigned sec
 | 27 | Post-Generation Pipeline | 27.1-27.8 |
 | 28 | Models Command | 28.1-28.8 |
 | 29 | Cost Tracking | 29.1-29.6 |
+| 30 | Repo Type API Validation | 30.1-30.3 |
+| 31 | Repo Type UI Elements | 31.1-31.4 |
+| 32 | Repo Type CLI | 32.1-32.3 |
 | 21 | Cleanup and Teardown | 21.1-21.5 |
 
 ---


### PR DESCRIPTION
## Summary

Adds a `repo_type` field (app, tests, library, framework) that controls how documentation is planned and generated based on the type of repository. What counts as "user-facing" now depends on the repo type.

## Changes

### Model Layer
- `RepoType` literal type and `REPO_TYPES` constant in `models.py`
- `repo_type` field on `GenerateRequest` (optional, default: auto-detect) and `DocPlan`

### Prompts (core of the feature)
- 4 type-specific navigation structures (app, tests, library, framework)
- Type-specific writing rules for guide/concept/reference pages
- Auto-detection block in planner prompt when repo_type is not specified
- Completeness guards on all repo-type maps (import-time validation)

### Backend
- `repo_type` column in DB with migration for existing databases
- Threaded through: generator → planner → page generation → incremental updates
- API validates and stores repo_type, returns in response
- AI-returned repo_type validated against REPO_TYPES before DB storage
- Up-to-date fast path preserves repo_type from base variant

### CLI
- `--repo-type / -t` flag with validation

### Frontend
- Repo type dropdown on GenerateForm (Auto-detect + 4 types)
- Session persistence for selected type
- Repo type display in VariantDetail info grid
- Regenerate preserves stored repo_type
- Model field no longer auto-fills (server default applies)

### Infrastructure
- Dockerfile: node 20→22, python 3.12→3.14

### Tests & Docs
- E2e test plan: `test-plans/e2e-15-repo-type.md` (Tests 30-32, 10 sub-tests)
- Updated AGENTS.md constants table
- Updated docsfy-generate-docs skill

## How it works

| Repo type | "User" is... | Focus |
|---|---|---|
| `app` (default) | End user | Installation, configuration, features, workflows |
| `tests` | Test developer | Fixtures, patterns, domain structure, shared utilities |
| `library` | Developer integrating it | Public API, classes, extension points, examples |
| `framework` | Developer building on it | Plugin system, lifecycle hooks, architecture |

Closes #65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repository type support for docs generation (app, tests, library, framework) with Auto-detect default
  * "Repository Type" dropdown in the generate form (persists in session); variant details show capitalized Repo Type
  * CLI --repo-type option; invalid values error and provided value is printed
  * API accepts, validates, persists, and echoes repo_type

* **Chores**
  * Updated base container images to Node 22 and Python 3.14

* **Documentation**
  * CLI/workflow docs updated to document --repo-type usage

* **Tests**
  * Added end-to-end test plans for repo type API/UI/CLI behaviors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/myk-org/docsfy/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->