### PR TITLE
fix: extract shared RoleBadge component, deduplicate badge classes (#92)

### DIFF
--- a/frontend/src/components/admin/UsersPanel.tsx
+++ b/frontend/src/components/admin/UsersPanel.tsx
@@ -4,7 +4,6 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { Badge } from '@/components/ui/badge'
 import {
   Select,
   SelectContent,
@@ -26,31 +25,10 @@ import { api } from '@/lib/api'
 import { TOAST_DEFAULT_MS, TOAST_ERROR_MS } from '@/lib/constants'
 import { ApiError } from '@/types'
 import type { User, CreateUserResponse, RotateKeyResponse } from '@/types'
+import RoleBadge from '@/components/shared/RoleBadge'
 
 function formatDate(dateStr: string): string {
   return new Date(dateStr).toLocaleString()
-}
-
-function RoleBadge({ role }: { role: string }) {
-  if (role === 'admin') {
-    return (
-      <Badge className="bg-signal-green/10 text-signal-green border-signal-green/20">
-        {role}
-      </Badge>
-    )
-  }
-  if (role === 'user') {
-    return (
-      <Badge className="bg-signal-blue/10 text-signal-blue border-signal-blue/20">
-        {role}
-      </Badge>
-    )
-  }
-  return (
-    <Badge className="bg-surface-elevated text-text-tertiary border-border-default">
-      {role}
-    </Badge>
-  )
 }
 
 export default function UsersPanel() {

--- a/frontend/src/components/shared/ApiKeyDisplay.tsx
+++ b/frontend/src/components/shared/ApiKeyDisplay.tsx
@@ -1,8 +1,8 @@
 import { useState, useRef, useEffect } from 'react'
 import { AlertTriangle, Check, Copy } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
 import { COPY_FEEDBACK_MS } from '@/lib/constants'
+import RoleBadge from '@/components/shared/RoleBadge'
 
 interface ApiKeyDisplayProps {
   username: string
@@ -88,19 +88,5 @@ export default function ApiKeyDisplay({
         </Button>
       </div>
     </div>
-  )
-}
-
-const ROLE_STYLES: Record<string, string> = {
-  admin: 'bg-signal-green/10 text-signal-green border-signal-green/20',
-  user: 'bg-signal-blue/10 text-signal-blue border-signal-blue/20',
-}
-const DEFAULT_ROLE_STYLE = 'bg-surface-elevated text-text-tertiary border-border-default'
-
-function RoleBadge({ role }: { role: string }) {
-  return (
-    <Badge className={ROLE_STYLES[role] || DEFAULT_ROLE_STYLE}>
-      {role}
-    </Badge>
   )
 }

--- a/frontend/src/components/shared/RoleBadge.tsx
+++ b/frontend/src/components/shared/RoleBadge.tsx
@@ -1,0 +1,15 @@
+import { Badge } from '@/components/ui/badge'
+
+const ROLE_STYLES: Record<string, string> = {
+  admin: 'bg-signal-green/10 text-signal-green border-signal-green/20',
+  user: 'bg-signal-blue/10 text-signal-blue border-signal-blue/20',
+}
+const DEFAULT_ROLE_STYLE = 'bg-surface-elevated text-text-tertiary border-border-default'
+
+export default function RoleBadge({ role }: { role: string }) {
+  return (
+    <Badge className={ROLE_STYLES[role] || DEFAULT_ROLE_STYLE}>
+      {role}
+    </Badge>
+  )
+}

--- a/frontend/src/components/shared/RoleBadge.tsx
+++ b/frontend/src/components/shared/RoleBadge.tsx
@@ -1,14 +1,14 @@
 import { Badge } from '@/components/ui/badge'
+import { BADGE_STYLES } from '@/lib/constants'
 
-const ROLE_STYLES: Record<string, string> = {
-  admin: 'bg-signal-green/10 text-signal-green border-signal-green/20',
-  user: 'bg-signal-blue/10 text-signal-blue border-signal-blue/20',
-}
-const DEFAULT_ROLE_STYLE = 'bg-surface-elevated text-text-tertiary border-border-default'
+const ROLE_BADGE_MAP = new Map<string, string>([
+  ['admin', BADGE_STYLES.green],
+  ['user', BADGE_STYLES.blue],
+])
 
 export default function RoleBadge({ role }: { role: string }) {
   return (
-    <Badge className={ROLE_STYLES[role] || DEFAULT_ROLE_STYLE}>
+    <Badge className={ROLE_BADGE_MAP.get(role) ?? BADGE_STYLES.muted}>
       {role}
     </Badge>
   )

--- a/frontend/src/components/shared/VariantDetail.tsx
+++ b/frontend/src/components/shared/VariantDetail.tsx
@@ -25,7 +25,7 @@ import Combobox from '@/components/shared/Combobox'
 import ActivityLog from '@/components/shared/ActivityLog'
 import { useModal } from '@/components/shared/ModalProvider'
 import { api } from '@/lib/api'
-import { TOAST_DEFAULT_MS, TOAST_ERROR_MS, VALID_PROVIDERS } from '@/lib/constants'
+import { TOAST_DEFAULT_MS, TOAST_ERROR_MS, VALID_PROVIDERS, BADGE_STYLES } from '@/lib/constants'
 import { ApiError } from '@/types'
 import type { Project, LogEntry, DocPlan, AvailableModels } from '@/types'
 
@@ -126,16 +126,16 @@ function StatusBadge({ status }: { status: Project['status'] }) {
     aborted: 'Documentation generation was aborted',
   }
   if (status === 'ready') {
-    return <Badge data-testid="status-text" className="bg-signal-green/10 text-signal-green border-signal-green/20" title={titles[status]}>Ready</Badge>
+    return <Badge data-testid="status-text" className={BADGE_STYLES.green} title={titles[status]}>Ready</Badge>
   }
   if (status === 'generating') {
-    return <Badge data-testid="status-text" className="bg-signal-blue/10 text-signal-blue border-signal-blue/20 animate-pulse" title={titles[status]}>Generating</Badge>
+    return <Badge data-testid="status-text" className={`${BADGE_STYLES.blue} animate-pulse`} title={titles[status]}>Generating</Badge>
   }
   if (status === 'error') {
     return <Badge data-testid="status-text" variant="destructive" title={titles[status]}>Error</Badge>
   }
   if (status === 'aborted') {
-    return <Badge data-testid="status-text" className="bg-signal-orange/10 text-signal-orange border-signal-orange/20" title={titles[status]}>Aborted</Badge>
+    return <Badge data-testid="status-text" className={BADGE_STYLES.orange} title={titles[status]}>Aborted</Badge>
   }
   return null
 }

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -41,3 +41,13 @@ export const GENERATION_STAGES = [
   'cross_linking',
   'rendering',
 ] as const
+
+/** Shared badge style class strings for signal colors — single source of truth */
+export const BADGE_STYLES = {
+  green: 'bg-signal-green/10 text-signal-green border-signal-green/20',
+  blue: 'bg-signal-blue/10 text-signal-blue border-signal-blue/20',
+  red: 'bg-signal-red/10 text-signal-red border-signal-red/20',
+  orange: 'bg-signal-orange/10 text-signal-orange border-signal-orange/20',
+  purple: 'bg-signal-purple/10 text-signal-purple border-signal-purple/20',
+  muted: 'bg-surface-elevated text-text-tertiary border-border-default',
+} as const


### PR DESCRIPTION
Closes #92

## Summary

Address Qodo review findings from PR #90.

### Changes
- **Extract shared `RoleBadge`** — Move `RoleBadge` component and `ROLE_STYLES` map to `frontend/src/components/shared/RoleBadge.tsx`
- **Remove duplicates** — Delete local `RoleBadge` implementations from `UsersPanel.tsx` and `ApiKeyDisplay.tsx`, import shared version
- **Document intentional behavior** — Updated issue #89 to document the always-visible repo summary as an intentional UX improvement

## Testing
- ✅ `npm run build` passes
- ✅ `npm test` — 5/5 tests pass