### PR TITLE
fix: pass SIDECAR_TOOLS to all call_ai_once call sites

### DIFF
--- a/src/docsfy/code_graph.py
+++ b/src/docsfy/code_graph.py
@@ -14,6 +14,7 @@ from typing import Any
 from simple_logger.logger import get_logger
 
 from docsfy.ai_client import AIResult, call_ai_once, run_parallel_with_limit
+from docsfy.prompts import SIDECAR_TOOLS
 
 logger = get_logger(name=__name__)
 
@@ -132,6 +133,7 @@ async def _extract_semantic_chunk(
         system_prompt=_EXTRACTION_SYSTEM,
         cwd=str(root),
         ai_call_timeout=ai_call_timeout,
+        tools=list(SIDECAR_TOOLS),
     )
 
     if not result.success:
@@ -327,6 +329,7 @@ async def _label_communities(
         ai_model=ai_model,
         cwd=str(repo_dir),
         ai_call_timeout=ai_call_timeout,
+        tools=list(SIDECAR_TOOLS),
     )
 
     if not result.success:

--- a/src/docsfy/postprocess.py
+++ b/src/docsfy/postprocess.py
@@ -21,6 +21,7 @@ from docsfy.json_parser import parse_json_array_response, parse_json_response
 from docsfy.models import PAGE_TYPES
 from docsfy.config import get_settings
 from docsfy.prompts import (
+    SIDECAR_TOOLS,
     build_completeness_prompt,
     build_cross_links_prompt,
     build_validation_prompt,
@@ -401,6 +402,7 @@ async def _validate_single_page(
         ai_model=ai_model,
         cwd=str(repo_path),
         ai_call_timeout=ai_cli_timeout,
+        tools=list(SIDECAR_TOOLS),
     )
     add_cost(result.usage.cost_usd if result.usage else None)
 
@@ -611,6 +613,7 @@ async def check_and_fill_completeness(
             ai_model=ai_model,
             cwd=str(repo_path),
             ai_call_timeout=ai_cli_timeout,
+            tools=list(SIDECAR_TOOLS),
         )
         add_cost(result.usage.cost_usd if result.usage else None)
 
@@ -821,6 +824,7 @@ async def add_cross_links(
                 ai_model=ai_model,
                 cwd=str(repo_path),
                 ai_call_timeout=ai_cli_timeout,
+                tools=list(SIDECAR_TOOLS),
             )
         except Exception as exc:
             logger.warning(


### PR DESCRIPTION
## Problem

`code_graph.py` and `postprocess.py` call `call_ai_once` without passing `tools`, so the sidecar defaults to `["read", "grep", "find", "ls", "bash"]` — giving the AI bash access.

## Fix

Pass `tools=list(SIDECAR_TOOLS)` to all 5 remaining `call_ai_once` calls:
- `code_graph.py`: 2 calls (`_extract_semantic_chunk`, `_label_communities`)
- `postprocess.py`: 3 calls (`_validate_single_page`, `check_and_fill_completeness`, `add_cross_links`)

Combined with the previous PR (#98), all 6 `call_ai_once` call sites now explicitly pass `tools=["read", "ls", "find", "grep"]` — no bash.