### PR TITLE
feat: show completeness_check stage in UI + track generation duration

### DIFF
--- a/frontend/src/components/shared/ActivityLog.tsx
+++ b/frontend/src/components/shared/ActivityLog.tsx
@@ -19,7 +19,9 @@ const ENTRY_ICONS = {
 
 function StatusHeader({ status, currentStage }: { status: ProjectStatus; currentStage?: string | null }) {
   if (status === 'generating') {
-    const label = (currentStage && STAGE_LABELS[currentStage]) || 'Generating...'
+    const label = (currentStage && currentStage in STAGE_LABELS
+      ? STAGE_LABELS[currentStage as keyof typeof STAGE_LABELS]
+      : null) || 'Generating...'
     return (
       <div className="flex items-center gap-2 text-sm font-medium text-signal-blue" title="Generation in progress">
         <Loader2 className="size-4 animate-spin" />

--- a/frontend/src/components/shared/ActivityLog.tsx
+++ b/frontend/src/components/shared/ActivityLog.tsx
@@ -1,11 +1,13 @@
 import { useRef, useEffect } from 'react'
 import { CheckCircle2, Loader2, XCircle, Circle } from 'lucide-react'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { STAGE_LABELS } from '@/lib/constants'
 import type { LogEntry, ProjectStatus } from '@/types'
 
 interface ActivityLogProps {
   entries: LogEntry[]
   status: ProjectStatus
+  currentStage?: string | null
 }
 
 const ENTRY_ICONS = {
@@ -15,12 +17,13 @@ const ENTRY_ICONS = {
   pending: <Circle className="size-3.5 text-text-secondary opacity-50 shrink-0" />,
 } as const
 
-function StatusHeader({ status }: { status: ProjectStatus }) {
+function StatusHeader({ status, currentStage }: { status: ProjectStatus; currentStage?: string | null }) {
   if (status === 'generating') {
+    const label = (currentStage && STAGE_LABELS[currentStage]) || 'Generating...'
     return (
       <div className="flex items-center gap-2 text-sm font-medium text-signal-blue" title="Generation in progress">
         <Loader2 className="size-4 animate-spin" />
-        Generating...
+        {label}
       </div>
     )
   }
@@ -42,7 +45,7 @@ function StatusHeader({ status }: { status: ProjectStatus }) {
   return null
 }
 
-export default function ActivityLog({ entries, status }: ActivityLogProps) {
+export default function ActivityLog({ entries, status, currentStage }: ActivityLogProps) {
   const bottomRef = useRef<HTMLDivElement>(null)
   const scrollAreaRef = useRef<HTMLDivElement>(null)
   const isAtBottomRef = useRef(true)
@@ -73,7 +76,7 @@ export default function ActivityLog({ entries, status }: ActivityLogProps) {
         <span className="text-xs font-semibold uppercase tracking-wider text-text-secondary">
           Activity Log
         </span>
-        <StatusHeader status={status} />
+        <StatusHeader status={status} currentStage={currentStage} />
       </div>
       <ScrollArea ref={scrollAreaRef} className="h-[300px]">
         <div className="p-3 flex flex-col gap-1.5">

--- a/frontend/src/components/shared/ActivityLog.tsx
+++ b/frontend/src/components/shared/ActivityLog.tsx
@@ -19,7 +19,7 @@ const ENTRY_ICONS = {
 
 function StatusHeader({ status, currentStage }: { status: ProjectStatus; currentStage?: string | null }) {
   if (status === 'generating') {
-    const label = (currentStage && currentStage in STAGE_LABELS
+    const label = (currentStage && Object.hasOwn(STAGE_LABELS, currentStage)
       ? STAGE_LABELS[currentStage as keyof typeof STAGE_LABELS]
       : null) || 'Generating...'
     return (

--- a/frontend/src/components/shared/VariantDetail.tsx
+++ b/frontend/src/components/shared/VariantDetail.tsx
@@ -30,6 +30,34 @@ import { TOAST_DEFAULT_MS, TOAST_ERROR_MS, VALID_PROVIDERS, BADGE_STYLES, SELECT
 import { ApiError } from '@/types'
 import type { Project, LogEntry, DocPlan, AvailableModels } from '@/types'
 
+function formatDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  if (m < 60) return s > 0 ? `${m}m ${s}s` : `${m}m`
+  const h = Math.floor(m / 60)
+  const rm = m % 60
+  return rm > 0 ? `${h}h ${rm}m` : `${h}h`
+}
+
+function useElapsedTime(startedAt: string | null | undefined): string | null {
+  const [elapsed, setElapsed] = useState<string | null>(null)
+  useEffect(() => {
+    if (!startedAt) {
+      setElapsed(null)
+      return
+    }
+    function tick() {
+      const diff = Math.max(0, Math.floor((Date.now() - new Date(startedAt!).getTime()) / 1000))
+      setElapsed(formatDuration(diff))
+    }
+    tick()
+    const id = setInterval(tick, 1000)
+    return () => clearInterval(id)
+  }, [startedAt])
+  return elapsed
+}
+
 interface VariantDetailProps {
   project: Project
   logEntries: LogEntry[]
@@ -217,6 +245,12 @@ function InfoGrid({ project, isAdmin }: { project: Project; isAdmin: boolean }) 
         <div>
           <span className="text-text-secondary">Generation Cost</span>
           <div className="mt-0.5 font-medium">${project.total_cost_usd.toFixed(4)}</div>
+        </div>
+      )}
+      {project.generation_duration != null && (
+        <div>
+          <span className="text-text-secondary">Generation Time</span>
+          <div className="mt-0.5 font-medium">{formatDuration(project.generation_duration)}</div>
         </div>
       )}
       {project.generation_id && (
@@ -474,7 +508,7 @@ function ReadyView({
 
       {/* Activity log */}
       {logEntries.length > 0 && (
-        <ActivityLog entries={logEntries} status={project.status} />
+        <ActivityLog entries={logEntries} status={project.status} currentStage={project.current_stage} />
       )}
 
       {/* Actions */}
@@ -545,6 +579,7 @@ function GeneratingView({
 }) {
   const { modalConfirm } = useModal()
   const [isAborting, setIsAborting] = useState(false)
+  const elapsed = useElapsedTime(project.generation_started_at)
 
   const totalPages = getTotalPages(project.plan_json)
   const progressPercent = totalPages > 0 ? Math.round((project.page_count / totalPages) * 100) : 0
@@ -587,8 +622,15 @@ function GeneratingView({
         </div>
       )}
 
+      {/* Elapsed time */}
+      {elapsed && (
+        <div className="text-xs text-text-secondary">
+          Elapsed: {elapsed}
+        </div>
+      )}
+
       {/* Activity log */}
-      <ActivityLog entries={logEntries} status={project.status} />
+      <ActivityLog entries={logEntries} status={project.status} currentStage={project.current_stage} />
 
       {/* Abort button — hidden for viewers */}
       {role !== 'viewer' && (
@@ -661,7 +703,7 @@ function ErrorAbortedView({
 
       {/* Activity log */}
       {logEntries.length > 0 && (
-        <ActivityLog entries={logEntries} status={project.status} />
+        <ActivityLog entries={logEntries} status={project.status} currentStage={project.current_stage} />
       )}
 
       {/* Regenerate + Delete (hidden for viewers) */}

--- a/frontend/src/components/shared/VariantDetail.tsx
+++ b/frontend/src/components/shared/VariantDetail.tsx
@@ -247,7 +247,7 @@ function InfoGrid({ project, isAdmin }: { project: Project; isAdmin: boolean }) 
           <div className="mt-0.5 font-medium">${project.total_cost_usd.toFixed(4)}</div>
         </div>
       )}
-      {project.generation_duration != null && (
+      {project.status === 'ready' && project.generation_duration != null && (
         <div>
           <span className="text-text-secondary">Generation Time</span>
           <div className="mt-0.5 font-medium">{formatDuration(project.generation_duration)}</div>

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -46,6 +46,20 @@ export const GENERATION_STAGES = [
   'rendering',
 ] as const
 
+/** Human-readable labels for each generation stage — single source of truth */
+export const STAGE_LABELS: Record<typeof GENERATION_STAGES[number], string> = {
+  cloning: 'Cloning...',
+  analyzing: 'Analyzing...',
+  cataloging_images: 'Cataloging images...',
+  planning: 'Planning...',
+  incremental_planning: 'Planning...',
+  generating_pages: 'Generating pages...',
+  validating: 'Validating...',
+  completeness_check: 'Checking completeness...',
+  cross_linking: 'Cross-linking...',
+  rendering: 'Rendering...',
+}
+
 /** Shared badge style class strings for signal colors — single source of truth */
 export const BADGE_STYLES = {
   green: 'bg-signal-green/10 text-signal-green border-signal-green/20',

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -240,6 +240,7 @@ export default function DashboardPage() {
                 plan_json: message.plan_json ?? p.plan_json,
                 error_message: message.error_message ?? p.error_message,
                 generation_id: message.generation_id ?? p.generation_id,
+                generation_started_at: message.generation_started_at ?? p.generation_started_at,
               }
             : p
         )
@@ -273,6 +274,8 @@ export default function DashboardPage() {
                 last_commit_sha: message.last_commit_sha ?? p.last_commit_sha,
                 error_message: message.error_message ?? p.error_message,
                 generation_id: message.generation_id ?? p.generation_id,
+                generation_duration: message.generation_duration ?? p.generation_duration,
+                generation_started_at: null,
               }
             : p
         )
@@ -739,6 +742,22 @@ function buildLogEntries(project: Project): LogEntry[] {
             timestamp: Date.now(),
           })
         }
+      }
+    }
+
+    // Gap pages generated during completeness check
+    if (currentIdx >= completenessIdx && project.page_count > totalPages) {
+      const gapCount = project.page_count - totalPages
+      for (let i = 0; i < gapCount; i++) {
+        const isLast = i === gapCount - 1
+        entries.push({
+          id: `gap-${i}`,
+          type: currentIdx === completenessIdx && isLast ? 'active' : 'done',
+          message: currentIdx === completenessIdx && isLast
+            ? `Generating gap page ${totalPages + i + 1}...`
+            : `Generated gap page ${totalPages + i + 1} (coverage gap)`,
+          timestamp: Date.now(),
+        })
       }
     }
   }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -125,6 +125,7 @@ export interface ProgressMessage {
   plan_json?: string | null
   error_message?: string | null
   generation_id?: string | null
+  generation_started_at?: string | null
 }
 
 export interface StatusChangeMessage {
@@ -140,6 +141,7 @@ export interface StatusChangeMessage {
   last_commit_sha?: string | null
   error_message?: string | null
   generation_id?: string | null
+  generation_duration?: number | null
 }
 
 export class ApiError extends Error {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -28,6 +28,8 @@ export interface Project {
   vision_provider: string | null
   vision_model: string | null
   generation_id: string | null
+  generation_duration: number | null
+  generation_started_at: string | null
   created_at: string
   updated_at: string
 }

--- a/src/docsfy/api/projects.py
+++ b/src/docsfy/api/projects.py
@@ -33,6 +33,8 @@ from docsfy.generator import (
 )
 from docsfy.models import (
     DEFAULT_BRANCH,
+    FIELD_GENERATION_DURATION,
+    FIELD_GENERATION_STARTED_AT,
     REPO_TYPES,
     VALID_PROVIDERS,
     GenerateRequest,
@@ -160,9 +162,9 @@ async def update_and_notify(
     if vision_model is not None:
         ups_kwargs["vision_model"] = vision_model
     if generation_duration is not None:
-        ups_kwargs["generation_duration"] = generation_duration
+        ups_kwargs[FIELD_GENERATION_DURATION] = generation_duration
     if generation_started_at is not None:
-        ups_kwargs["generation_started_at"] = generation_started_at
+        ups_kwargs[FIELD_GENERATION_STARTED_AT] = generation_started_at
 
     # Always pass current_stage through so that None clears the stage in the DB.
     ups_kwargs["current_stage"] = current_stage

--- a/src/docsfy/api/projects.py
+++ b/src/docsfy/api/projects.py
@@ -7,6 +7,7 @@ import shutil
 import socket
 import tarfile
 import tempfile
+import time
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
 from pathlib import Path
@@ -132,6 +133,8 @@ async def update_and_notify(
     repo_type: str | None = None,
     vision_provider: str | None = None,
     vision_model: str | None = None,
+    generation_duration: int | None = None,
+    generation_started_at: str | None = None,
 ) -> None:
     """Update project status in DB and send WebSocket notification."""
     ups_kwargs: dict[str, Any] = {
@@ -156,6 +159,10 @@ async def update_and_notify(
         ups_kwargs["vision_provider"] = vision_provider
     if vision_model is not None:
         ups_kwargs["vision_model"] = vision_model
+    if generation_duration is not None:
+        ups_kwargs["generation_duration"] = generation_duration
+    if generation_started_at is not None:
+        ups_kwargs["generation_started_at"] = generation_started_at
 
     # Always pass current_stage through so that None clears the stage in the DB.
     ups_kwargs["current_stage"] = current_stage
@@ -175,6 +182,7 @@ async def update_and_notify(
             last_commit_sha=last_commit_sha,
             error_message=error_message,
             generation_id=generation_id,
+            generation_duration=generation_duration,
         )
         await notify_sync()
     else:
@@ -186,6 +194,7 @@ async def update_and_notify(
             plan_json=plan_json,
             error_message=error_message,
             generation_id=generation_id,
+            generation_started_at=generation_started_at,
         )
 
 
@@ -568,6 +577,8 @@ async def _run_generation(
     gen_key = f"{owner}/{project_name}/{encode_branch_for_path(branch)}/{ai_provider}/{ai_model}"
     cost_acc = CostAccumulator()
     cost_token = set_cost_accumulator(cost_acc)
+    generation_start = time.monotonic()
+    generation_started_at = datetime.now(UTC).isoformat()
     try:
         available, msg = await check_sidecar_available()
         if not available:
@@ -596,6 +607,7 @@ async def _run_generation(
             generation_id=generation_id,
             vision_provider=vision_provider or "",
             vision_model=vision_model or "",
+            generation_started_at=generation_started_at,
         )
 
         if repo_path:
@@ -618,6 +630,8 @@ async def _run_generation(
                 repo_type=repo_type,
                 vision_provider=vision_provider,
                 vision_model=vision_model,
+                generation_start=generation_start,
+                generation_started_at=generation_started_at,
             )
         else:
             # Remote repository - clone to temp dir
@@ -643,6 +657,8 @@ async def _run_generation(
                     repo_type=repo_type,
                     vision_provider=vision_provider,
                     vision_model=vision_model,
+                    generation_start=generation_start,
+                    generation_started_at=generation_started_at,
                 )
 
     except asyncio.CancelledError:
@@ -717,6 +733,8 @@ async def _generate_from_path(
     repo_type: str | None = None,
     vision_provider: str | None = None,
     vision_model: str | None = None,
+    generation_start: float | None = None,
+    generation_started_at: str | None = None,
 ) -> None:
     cache_dir = get_project_cache_dir(
         project_name, ai_provider, ai_model, owner, branch=branch
@@ -796,6 +814,7 @@ async def _generate_from_path(
             branch=branch,
             page_count=0,
             generation_id=generation_id,
+            generation_started_at=generation_started_at,
         )
     else:
         current_variant = await get_project(
@@ -929,6 +948,7 @@ async def _generate_from_path(
                         current_stage="incremental_planning",
                         page_count=0,
                         generation_id=generation_id,
+                        generation_started_at=generation_started_at,
                     )
                     pages_to_regen = await run_incremental_planner(
                         repo_dir,
@@ -1004,6 +1024,7 @@ async def _generate_from_path(
         current_stage="analyzing",
         page_count=0,
         generation_id=generation_id,
+        generation_started_at=generation_started_at,
     )
     graph_report = await build_code_graph(
         repo_dir, ai_provider, ai_model, ai_cli_timeout
@@ -1028,6 +1049,7 @@ async def _generate_from_path(
             current_stage="cataloging_images",
             page_count=0,
             generation_id=generation_id,
+            generation_started_at=generation_started_at,
         )
         image_catalog = await build_image_catalog(
             repo_path=repo_dir,
@@ -1060,6 +1082,7 @@ async def _generate_from_path(
             current_stage="planning",
             page_count=0,
             generation_id=generation_id,
+            generation_started_at=generation_started_at,
         )
 
         plan = await run_planner(
@@ -1111,15 +1134,19 @@ async def _generate_from_path(
         page_count=current_page_count,
         generation_id=generation_id,
         repo_type=detected_repo_type,
+        generation_started_at=generation_started_at,
     )
 
-    async def _on_page_generated(page_count: int) -> None:
+    async def _on_page_generated(
+        page_count: int, *, stage: str = "generating_pages"
+    ) -> None:
         await notify_progress(
             gen_key=gen_key,
             status="generating",
-            current_stage="generating_pages",
+            current_stage=stage,
             page_count=page_count,
             generation_id=generation_id,
+            generation_started_at=generation_started_at,
         )
 
     try:
@@ -1160,6 +1187,7 @@ async def _generate_from_path(
             current_stage="validating",
             page_count=len(pages),
             generation_id=generation_id,
+            generation_started_at=generation_started_at,
         )
         pages = await validate_pages(
             pages=pages,
@@ -1189,7 +1217,12 @@ async def _generate_from_path(
             current_stage="completeness_check",
             page_count=len(pages),
             generation_id=generation_id,
+            generation_started_at=generation_started_at,
         )
+
+        async def _on_completeness_page(page_count: int) -> None:
+            await _on_page_generated(page_count, stage="completeness_check")
+
         pages, plan = await check_and_fill_completeness(
             pages=pages,
             repo_path=repo_dir,
@@ -1202,7 +1235,7 @@ async def _generate_from_path(
             graph_report_path=graph_report,
             graph_report_available=graph_report is not None,
             repo_type=detected_repo_type,
-            on_page_generated=_on_page_generated,
+            on_page_generated=_on_completeness_page,
             owner=owner,
             branch=branch,
         )
@@ -1220,6 +1253,7 @@ async def _generate_from_path(
                 page_count=len(pages),
                 generation_id=generation_id,
                 plan_json=json.dumps(plan),
+                generation_started_at=generation_started_at,
             )
     except Exception as exc:
         logger.warning(f"[{project_name}] Completeness check failed: {exc}")
@@ -1236,6 +1270,7 @@ async def _generate_from_path(
             current_stage="cross_linking",
             page_count=len(pages),
             generation_id=generation_id,
+            generation_started_at=generation_started_at,
         )
         pages = fix_broken_internal_links(pages, plan, project_name=project_name)
         try:
@@ -1271,6 +1306,7 @@ async def _generate_from_path(
         current_stage="rendering",
         page_count=len(pages),
         generation_id=generation_id,
+        generation_started_at=generation_started_at,
     )
 
     site_dir = get_project_site_dir(
@@ -1302,6 +1338,9 @@ async def _generate_from_path(
         page_count=page_count,
         plan_json=json.dumps(plan),
         generation_id=generation_id,
+        generation_duration=int(time.monotonic() - generation_start)
+        if generation_start
+        else None,
     )
     logger.info(f"[{project_name}] Documentation ready ({page_count} pages)")
 

--- a/src/docsfy/api/websocket.py
+++ b/src/docsfy/api/websocket.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from simple_logger.logger import get_logger
 
 from docsfy.config import get_settings
+from docsfy.models import FIELD_GENERATION_DURATION, FIELD_GENERATION_STARTED_AT
 from docsfy.storage import (
     get_session,
     get_user_by_key,
@@ -256,7 +257,7 @@ async def notify_progress(
     if error_message is not None:
         message["error_message"] = error_message
     if generation_started_at is not None:
-        message["generation_started_at"] = generation_started_at
+        message[FIELD_GENERATION_STARTED_AT] = generation_started_at
 
     await _broadcast_to_relevant(message, owner, project_name)
 
@@ -298,7 +299,7 @@ async def notify_status_change(
     if error_message is not None:
         message["error_message"] = error_message
     if generation_duration is not None:
-        message["generation_duration"] = generation_duration
+        message[FIELD_GENERATION_DURATION] = generation_duration
 
     await _broadcast_to_relevant(message, owner, project_name)
 

--- a/src/docsfy/api/websocket.py
+++ b/src/docsfy/api/websocket.py
@@ -224,6 +224,7 @@ async def notify_progress(
     plan_json: str | None = None,
     error_message: str | None = None,
     generation_id: str | None = None,
+    generation_started_at: str | None = None,
 ) -> None:
     """Send a progress update for an in-progress generation."""
     # gen_key format: "owner/name/branch/provider/model"
@@ -254,6 +255,8 @@ async def notify_progress(
         message["plan_json"] = plan_json
     if error_message is not None:
         message["error_message"] = error_message
+    if generation_started_at is not None:
+        message["generation_started_at"] = generation_started_at
 
     await _broadcast_to_relevant(message, owner, project_name)
 
@@ -266,6 +269,7 @@ async def notify_status_change(
     last_commit_sha: str | None = None,
     error_message: str | None = None,
     generation_id: str | None = None,
+    generation_duration: int | None = None,
 ) -> None:
     """Send a status change notification (for terminal states)."""
     parts = gen_key.split("/", 4)
@@ -293,6 +297,8 @@ async def notify_status_change(
         message["last_commit_sha"] = last_commit_sha
     if error_message is not None:
         message["error_message"] = error_message
+    if generation_duration is not None:
+        message["generation_duration"] = generation_duration
 
     await _broadcast_to_relevant(message, owner, project_name)
 

--- a/src/docsfy/models.py
+++ b/src/docsfy/models.py
@@ -11,6 +11,10 @@ from docsfy.repository import extract_repo_name
 
 VALID_PROVIDERS = ("claude", "gemini", "cursor")
 DEFAULT_BRANCH = "main"
+
+# DB/API field names for generation timing — shared across projects.py, websocket.py, storage.py
+FIELD_GENERATION_DURATION = "generation_duration"
+FIELD_GENERATION_STARTED_AT = "generation_started_at"
 DOCSFY_DOCS_URL = "https://myk-org.github.io/docsfy/"
 DOCSFY_REPO_URL = "https://github.com/myk-org/docsfy"
 

--- a/src/docsfy/storage.py
+++ b/src/docsfy/storage.py
@@ -81,6 +81,8 @@ async def init_db(data_dir: str = "") -> None:
                 total_cost_usd REAL,
                 vision_provider TEXT DEFAULT '',
                 vision_model TEXT DEFAULT '',
+                generation_duration INTEGER,
+                generation_started_at TEXT,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 PRIMARY KEY (name, branch, ai_provider, ai_model, owner)
@@ -255,6 +257,19 @@ async def init_db(data_dir: str = "") -> None:
                 await db.execute(
                     f"ALTER TABLE projects ADD COLUMN {col} TEXT DEFAULT ''"
                 )
+                await db.commit()
+            except sqlite3.OperationalError as exc:
+                if "duplicate column name" not in str(exc).lower():
+                    logger.exception("Migration failed while adding %s column", col)
+                    raise
+
+        # Migration: add generation_duration and generation_started_at columns
+        for col, col_type in (
+            ("generation_duration", "INTEGER"),
+            ("generation_started_at", "TEXT"),
+        ):
+            try:
+                await db.execute(f"ALTER TABLE projects ADD COLUMN {col} {col_type}")
                 await db.commit()
             except sqlite3.OperationalError as exc:
                 if "duplicate column name" not in str(exc).lower():
@@ -447,6 +462,8 @@ async def update_project_status(
     repo_type: str | None = None,
     vision_provider: str | None = None,
     vision_model: str | None = None,
+    generation_duration: int | None = None,
+    generation_started_at: str | None = None,
 ) -> None:
     if status not in VALID_STATUSES:
         msg = f"Invalid project status: '{status}'. Valid: {', '.join(sorted(VALID_STATUSES))}"
@@ -481,6 +498,14 @@ async def update_project_status(
         if vision_model is not None:
             fields.append("vision_model = ?")
             values.append(vision_model)
+        if generation_duration is not None:
+            fields.append("generation_duration = ?")
+            values.append(generation_duration)
+        if generation_started_at is not None:
+            fields.append("generation_started_at = ?")
+            values.append(generation_started_at)
+        if status in ("ready", "error", "aborted"):
+            fields.append("generation_started_at = NULL")
         if status == "ready":
             fields.append("last_generated = CURRENT_TIMESTAMP")
         values.append(name)

--- a/src/docsfy/storage.py
+++ b/src/docsfy/storage.py
@@ -16,7 +16,11 @@ from typing import Any
 import aiosqlite
 from simple_logger.logger import get_logger
 
-from docsfy.models import DEFAULT_BRANCH
+from docsfy.models import (
+    DEFAULT_BRANCH,
+    FIELD_GENERATION_DURATION,
+    FIELD_GENERATION_STARTED_AT,
+)
 
 logger = get_logger(name=__name__)
 
@@ -265,8 +269,8 @@ async def init_db(data_dir: str = "") -> None:
 
         # Migration: add generation_duration and generation_started_at columns
         for col, col_type in (
-            ("generation_duration", "INTEGER"),
-            ("generation_started_at", "TEXT"),
+            (FIELD_GENERATION_DURATION, "INTEGER"),
+            (FIELD_GENERATION_STARTED_AT, "TEXT"),
         ):
             try:
                 await db.execute(f"ALTER TABLE projects ADD COLUMN {col} {col_type}")
@@ -499,15 +503,15 @@ async def update_project_status(
             fields.append("vision_model = ?")
             values.append(vision_model)
         if generation_duration is not None:
-            fields.append("generation_duration = ?")
+            fields.append(f"{FIELD_GENERATION_DURATION} = ?")
             values.append(generation_duration)
         if generation_started_at is not None:
-            fields.append("generation_started_at = ?")
+            fields.append(f"{FIELD_GENERATION_STARTED_AT} = ?")
             values.append(generation_started_at)
         if status in ("ready", "error", "aborted"):
-            fields.append("generation_started_at = NULL")
+            fields.append(f"{FIELD_GENERATION_STARTED_AT} = NULL")
         if status == "generating" and generation_duration is None:
-            fields.append("generation_duration = NULL")
+            fields.append(f"{FIELD_GENERATION_DURATION} = NULL")
         if status == "ready":
             fields.append("last_generated = CURRENT_TIMESTAMP")
         values.append(name)

--- a/src/docsfy/storage.py
+++ b/src/docsfy/storage.py
@@ -510,7 +510,7 @@ async def update_project_status(
             values.append(generation_started_at)
         if status in ("ready", "error", "aborted"):
             fields.append(f"{FIELD_GENERATION_STARTED_AT} = NULL")
-        if status == "generating" and generation_duration is None:
+        if status in ("generating", "error", "aborted") and generation_duration is None:
             fields.append(f"{FIELD_GENERATION_DURATION} = NULL")
         if status == "ready":
             fields.append("last_generated = CURRENT_TIMESTAMP")

--- a/src/docsfy/storage.py
+++ b/src/docsfy/storage.py
@@ -506,6 +506,8 @@ async def update_project_status(
             values.append(generation_started_at)
         if status in ("ready", "error", "aborted"):
             fields.append("generation_started_at = NULL")
+        if status == "generating" and generation_duration is None:
+            fields.append("generation_duration = NULL")
         if status == "ready":
             fields.append("last_generated = CURRENT_TIMESTAMP")
         values.append(name)

--- a/test-plans/e2e-13-post-generation-pipeline.md
+++ b/test-plans/e2e-13-post-generation-pipeline.md
@@ -8,7 +8,7 @@
 
 ## Test 27: Post-Generation Pipeline
 
-This test group verifies the features added by the post-generation pipeline: version detection in the footer, related-pages cross-links, and the validation and cross-linking stages that appear during generation.
+This test group verifies the features added by the post-generation pipeline: version detection in the footer, related-pages cross-links, the validation, completeness-check, and cross-linking stages that appear during generation, generation duration tracking and display, elapsed time indicator during active generation, and stage-specific status labels in the activity log header.
 
 **Precondition:** Log in as `testuser-e2e`. Ensure the `for-testing-only` repo is accessible.
 
@@ -200,6 +200,7 @@ agent-browser javascript "JSON.stringify(Array.from(window.__pipelineStages))"
 **Expected result:**
 - The returned array contains `"validating"` or a stage name containing `"validat"`
 - The returned array contains `"cross_linking"` or a stage name containing `"cross_link"` or `"crosslink"`
+- The returned array contains `"completeness_check"` or a stage name containing `"completeness"`
 - Both stages appear after the page-writing stages (they are post-processing)
 
 **Cleanup:**
@@ -267,9 +268,12 @@ agent-browser javascript "Array.from(document.querySelectorAll('[class*=\"activi
 
 **Expected result:**
 - The activity log list contains at least one entry with text matching `validat` (case-insensitive), such as "Validating pages", "Validation complete", or similar
+- The activity log list contains at least one entry with text matching `completeness` (case-insensitive), such as "Checking documentation completeness...", "Verified documentation completeness", or similar
 - The activity log list contains at least one entry with text matching `cross.link` (case-insensitive), such as "Cross-linking pages", "Cross-linking complete", or similar
-- Both entries appear after page-writing entries in the log order
+- All three entries appear after page-writing entries in the log order
 - These entries arrive via WebSocket without requiring a page refresh
+- The activity log status header shows stage-specific text (e.g., "Checking completeness...") instead of generic "Generating..." during the completeness_check stage
+- If the completeness check generated additional pages beyond the original plan, the activity log contains entries matching `gap page` (e.g., "Generated gap page 7 (coverage gap)"). These appear after the original page entries and before cross-linking
 
 ---
 
@@ -318,7 +322,121 @@ echo "Generation wall-clock time: ${ELAPSED}s"
 
 ---
 
-### 27.7 Cleanup
+### 27.7 Generation duration displayed for ready variants
+
+**Precondition:** A `ready` variant exists for `for-testing-only/main` (from test 27.1 or 27.6).
+
+**Commands:**
+
+```shell
+agent-browser navigate http://localhost:8800/
+agent-browser wait 2000
+```
+
+Click on the ready variant to open its detail view:
+
+```shell
+agent-browser click "[data-testid='variant-for-testing-only-main-gemini-gemini-2.5-flash']"
+agent-browser wait 1000
+agent-browser screenshot
+```
+
+**Check the info grid contains a "Generation Time" field:**
+
+```shell
+agent-browser javascript "Array.from(document.querySelectorAll('[class*=\"grid\"] > div')).map(div => div.textContent.trim()).join(' | ')"
+```
+
+**Expected result:**
+- The info grid contains a field labeled "Generation Time"
+- The value is a human-readable duration format (e.g., "2m 34s", "45s", "1h 5m")
+- The value is non-empty and non-zero
+
+---
+
+### 27.8 Generation duration tracked via API
+
+**Precondition:** A `ready` variant exists for `for-testing-only/main`.
+
+**Commands:**
+
+```shell
+curl -s -H "Cookie: $SESSION_COOKIE" http://localhost:8800/api/projects | python3 -c "import sys,json; data=json.load(sys.stdin); matches=[p for p in data['projects'] if p['name']=='for-testing-only' and p['branch']=='main' and p['ai_model']=='gemini-2.5-flash']; print('generation_duration:', matches[0].get('generation_duration')) if matches else print('NOT FOUND')"
+```
+
+**Expected result:**
+- The `generation_duration` field is present in the API response
+- The value is a positive integer representing seconds
+- The value is reasonable for the test repo (typically between 30 and 600 seconds)
+
+---
+
+### 27.9 Elapsed timer shown during active generation
+
+**Precondition:** Start a fresh force generation and immediately check the status page for elapsed time.
+
+**Commands:**
+
+```shell
+agent-browser javascript "fetch('/api/generate', {method:'POST', headers:{'Content-Type':'application/json'}, credentials:'same-origin', body:JSON.stringify({repo_url:'https://github.com/myk-org/for-testing-only', branch:'main', ai_provider:'gemini', ai_model:'gemini-2.5-flash', force:true})}).then(r => r.status)"
+agent-browser wait 5000
+agent-browser screenshot
+```
+
+**Check the generating view shows elapsed time:**
+
+```shell
+agent-browser javascript "document.body.innerText.includes('Elapsed')"
+```
+
+**Expected result:**
+- The page shows an "Elapsed: Xs" or "Elapsed: Xm Ys" indicator
+- The elapsed time updates every second (take two screenshots 3 seconds apart and compare the time values)
+- The elapsed time disappears once generation completes
+
+**Cleanup:**
+
+```shell
+agent-browser javascript "fetch('/api/projects/for-testing-only/main/gemini/gemini-2.5-flash/abort', {method:'POST', credentials:'same-origin'}).then(r => r.status)"
+agent-browser wait 3000
+```
+
+---
+
+### 27.10 Activity log status header shows stage-specific text
+
+**Precondition:** Start a fresh generation and observe the activity log header text.
+
+**Commands:**
+
+```shell
+agent-browser javascript "fetch('/api/generate', {method:'POST', headers:{'Content-Type':'application/json'}, credentials:'same-origin', body:JSON.stringify({repo_url:'https://github.com/myk-org/for-testing-only', branch:'main', ai_provider:'gemini', ai_model:'gemini-2.5-flash', force:true})}).then(r => r.status)"
+agent-browser wait 10000
+agent-browser screenshot
+```
+
+**Check the status header text is stage-specific:**
+
+```shell
+agent-browser javascript "document.querySelector('[class*=\"activity\"] [class*=\"header\"], [class*=\"log\"] [class*=\"header\"]')?.textContent"
+```
+
+**Expected result:**
+- During generation, the status header shows a stage-specific label such as:
+  - "Cloning...", "Analyzing...", "Planning...", "Generating pages...", "Validating...", "Checking completeness...", "Cross-linking...", "Rendering..."
+- The header does NOT show a generic "Generating..." when a specific stage is known
+- The label updates as the stage changes (observe multiple screenshots across different stages)
+
+**Cleanup:**
+
+```shell
+agent-browser javascript "fetch('/api/projects/for-testing-only/main/gemini/gemini-2.5-flash/abort', {method:'POST', credentials:'same-origin'}).then(r => r.status)"
+agent-browser wait 3000
+```
+
+---
+
+### 27.11 Cleanup
 
 Delete variants created during Test 27 that are not needed by later tests:
 

--- a/test-plans/e2e-ui-test-plan.md
+++ b/test-plans/e2e-ui-test-plan.md
@@ -163,7 +163,7 @@ Each linked sub-file contains only the detailed test bodies for its assigned sec
 | [e2e-10-branch-support.md](e2e-10-branch-support.md) | 22 | Branch Support (including regenerate with different branch) |
 | [e2e-11-websocket.md](e2e-11-websocket.md) | 23 | WebSocket Connection, Auth, Real-time Updates |
 | [e2e-12-cli.md](e2e-12-cli.md) | 24 | CLI Commands (config, generate, list, status, admin) |
-| [e2e-13-post-generation-pipeline.md](e2e-13-post-generation-pipeline.md) | 27 | Post-Generation Pipeline (version footer, related pages, validation/cross-linking stages, performance) |
+| [e2e-13-post-generation-pipeline.md](e2e-13-post-generation-pipeline.md) | 27 | Post-Generation Pipeline (version footer, related pages, validation/cross-linking/completeness stages, performance, generation duration, elapsed timer, stage labels) |
 | [e2e-14-models-command.md](e2e-14-models-command.md) | 28 | Models Command (CLI providers/models listing, JSON output, API endpoint, available_models) |
 | [e2e-15-repo-type.md](e2e-15-repo-type.md) | 30-32 | Repository type support (API, UI, CLI) |
 | [e2e-16-admin-settings.md](e2e-16-admin-settings.md) | 33 | Admin settings page (GET/PUT API, env override warnings, non-admin rejection, generate form defaults) |
@@ -203,7 +203,7 @@ Each linked sub-file contains only the detailed test bodies for its assigned sec
 | 24 | CLI Commands | 24.1-24.10 |
 | 25 | Sidebar Collapse Toggle Position | 25.1-25.4 |
 | 26 | Dialog Theme Consistency | 26.1-26.2 |
-| 27 | Post-Generation Pipeline | 27.1-27.8 |
+| 27 | Post-Generation Pipeline | 27.1-27.11 |
 | 28 | Models Command | 28.1-28.8 |
 | 29 | Cost Tracking | 29.1-29.6 |
 | 30 | Repo Type API Validation | 30.1-30.3 |


### PR DESCRIPTION
Fixes #106
Fixes #18

## What changed

### Bug fix: completeness_check not shown on web UI (#106)

**Root cause:** The `_on_page_generated` callback hardcoded `current_stage="generating_pages"`, so when pages were generated during `completeness_check`, the WebSocket sent `generating_pages` as the stage — causing the UI to regress.

**Fix:**
- `_on_page_generated` now accepts a `stage` parameter (defaults to `"generating_pages"`)
- New `_on_completeness_page` wrapper passes `stage="completeness_check"`
- Activity log shows gap pages distinctly (e.g., "Generated gap page 7 (coverage gap)")
- Status header now shows stage-specific text ("Checking completeness...", "Cross-linking...", etc.) instead of generic "Generating..."

### Feature: Track and display generation time (#18)

- **DB:** Added `generation_duration` (INTEGER, seconds) and `generation_started_at` (TEXT, ISO timestamp) columns with migration
- **Backend:** Records `time.monotonic()` at generation start, calculates duration on completion, broadcasts via WebSocket
- **Frontend:** Shows formatted duration ("2m 34s") in variant info grid, live elapsed timer during generation
- **Cleanup:** `generation_started_at` is cleared to NULL on terminal states (ready/error/aborted)

### Code quality (from reviewer feedback)

- `STAGE_LABELS` moved to `constants.ts`, typed as `Record<typeof GENERATION_STAGES[number], string>` for compile-time sync
- Stale `generation_started_at` cleared in DB on terminal states

## Files changed

| File | Changes |
|------|---------|
| `src/docsfy/storage.py` | New columns + migration + clear on terminal |
| `src/docsfy/api/projects.py` | Time tracking, stage callback fix |
| `src/docsfy/api/websocket.py` | New WS message fields |
| `frontend/src/lib/constants.ts` | `STAGE_LABELS` (typed, shared) |
| `frontend/src/types/index.ts` | New Project fields |
| `frontend/src/pages/DashboardPage.tsx` | WS handling + gap page display |
| `frontend/src/components/shared/ActivityLog.tsx` | Stage-specific header |
| `frontend/src/components/shared/VariantDetail.tsx` | Duration display + elapsed timer |
| `test-plans/e2e-13-post-generation-pipeline.md` | New tests 27.7-27.11 |
| `test-plans/e2e-ui-test-plan.md` | Updated summary |

## Testing

- ✅ 374 unit tests pass
- ✅ TypeScript compiles clean
- ✅ E2e test plans updated (27.7-27.11)