### PR TITLE
fix(skill): replace blocking --watch with polling in docsfy-generate-docs

### DIFF
--- a/skills/docsfy-generate-docs/SKILL.md
+++ b/skills/docsfy-generate-docs/SKILL.md
@@ -314,12 +314,16 @@ docsfy generate <repo_url> --branch <branch> --provider <provider> --model <mode
 - Add `--repo-type <type>` if user specified a repository type (app, tests, library, framework). If not specified (Auto-detect), omit the flag and let the AI auto-detect.
 
 The command returns immediately with the project name, branch, status, and generation ID.
-Extract the project name from the `Project:` line in the output — use this value (not the repo URL) for all subsequent `docsfy status` and `docsfy download` commands.
+Extract both values from the output:
+- `<project_name>` from the `Project:` line — used for the git branch name in Phase 3
+- `<generation_id>` from the `Generation ID:` line — used for `docsfy status` and `docsfy download` to avoid ambiguity
+
+Using the generation ID (a UUID) is preferred over project name for status/download because it uniquely identifies the generation and avoids HTTP 409 errors when multiple owners have the same project variant.
 
 **Poll for completion** using `docsfy status`:
 
 ```bash
-docsfy status <project_name> --branch <branch> --provider <provider> --model <model> --json
+docsfy status <generation_id> --json
 ```
 
 Check the `status` field in the JSON response:
@@ -367,10 +371,10 @@ This ensures docs changes are on a separate branch, not directly on the current 
 ### Phase 4: Download Generated Docs
 
 ```bash
-docsfy download <project_name> --branch <branch> --provider <provider> --model <model> --output <output_dir> --flatten
+docsfy download <generation_id> --output <output_dir> --flatten
 ```
 
-`<project_name>` is the same value extracted from the `docsfy generate` output in Phase 2.
+Use the `<generation_id>` from Phase 2 for an unambiguous download. The `<project_name>` from Phase 2 is used only for the git branch name.
 
 The `--flatten` flag extracts docs directly into `<output_dir>/` instead of creating a nested subdirectory. It also handles model names with special characters (e.g., brackets) safely.
 
@@ -555,10 +559,10 @@ Display:
 |---------|---------|
 | `docsfy generate <url>` | Start docs generation (returns immediately) |
 | `docsfy generate <url> --repo-type tests` | Generate docs for a test suite repo |
-| `docsfy status <name>` | Check generation status |
-| `docsfy download <name> -o <dir>` | Download docs to directory |
+| `docsfy status <generation_id>` | Check generation status |
+| `docsfy download <generation_id> -o <dir>` | Download docs to directory |
 | `docsfy list` | List all projects |
-| `docsfy abort <name>` | Abort active generation |
+| `docsfy abort <generation_id>` | Abort active generation |
 | `docsfy health` | Check server connectivity |
 | `docsfy list --json` | List all previously generated projects |
 | `docsfy models --json` | List all providers and their available models |

--- a/skills/docsfy-generate-docs/SKILL.md
+++ b/skills/docsfy-generate-docs/SKILL.md
@@ -559,8 +559,8 @@ Display:
 |---------|---------|
 | `docsfy generate <url>` | Start docs generation (returns immediately) |
 | `docsfy generate <url> --repo-type tests` | Generate docs for a test suite repo |
-| `docsfy status <generation_id>` | Check generation status |
-| `docsfy download <generation_id> -o <dir>` | Download docs to directory |
+| `docsfy status <generation_id> --json` | Check generation status (JSON output) |
+| `docsfy download <generation_id> -o <dir> --flatten` | Download docs to directory |
 | `docsfy list` | List all projects |
 | `docsfy abort <generation_id>` | Abort active generation |
 | `docsfy health` | Check server connectivity |

--- a/skills/docsfy-generate-docs/SKILL.md
+++ b/skills/docsfy-generate-docs/SKILL.md
@@ -303,19 +303,32 @@ Ask the user: **"Ready to proceed with generation?"** (Yes / No)
 
 ### Phase 2: Generate Documentation
 
-Run the generation command using **`Bash(run_in_background=true)`** since it is a long-running blocking operation:
+Run the generation command **without** `--watch` — it returns immediately:
 
 ```bash
-docsfy generate <repo_url> --branch <branch> --provider <provider> --model <model> --watch [--force] [--repo-type <type>]
+docsfy generate <repo_url> --branch <branch> --provider <provider> --model <model> [--force] [--repo-type <type>]
 ```
 
-- Always use `--watch` for real-time WebSocket progress
+- **Do NOT use `--watch`** — it blocks the chat session and prevents user interaction
 - Add `--force` only if user requested force regeneration
 - Add `--repo-type <type>` if user specified a repository type (app, tests, library, framework). If not specified (Auto-detect), omit the flag and let the AI auto-detect.
-- **Use `run_in_background=true`** on the Bash tool so the main conversation is not blocked.
-  You will be notified when the command completes.
 
-When the background command completes, check the output for status `ready`, `error`, or `aborted`.
+The command returns immediately with the project name, branch, status, and generation ID.
+Extract the project name from the `Project:` line in the output — use this value (not the repo URL) for all subsequent `docsfy status` and `docsfy download` commands.
+
+**Poll for completion** using `docsfy status`:
+
+```bash
+docsfy status <project_name> --branch <branch> --provider <provider> --model <model> --json
+```
+
+Check the `status` field in the JSON response:
+- `generating` → Still in progress. The `current_stage` field shows what's happening. Wait ~30 seconds and poll again.
+- `ready` → Generation complete. Proceed to Phase 3.
+- `error` → Generation failed. Show the `error_message` to the user and ask how to proceed.
+- `aborted` → Generation was aborted. Inform the user.
+
+**Poll interval:** Wait ~30 seconds between status checks. Show the user progress updates from `current_stage` when it changes.
 
 If generation fails, show the error and ask the user how to proceed.
 
@@ -328,7 +341,7 @@ After generation completes (status: `ready`), create a local branch to isolate d
 repository, inform them that the docs branch will be created in the current
 local repository and confirm before proceeding.
 
-**Extract `<project_name>`** from the repo URL: strip any trailing `/` and `.git` suffix, then take the last path segment (e.g., `docsfy` from `https://github.com/myk-org/docsfy.git`).
+Use the `<project_name>` extracted from the `docsfy generate` output in Phase 2.
 
 Before switching branches, check for uncommitted changes:
 
@@ -357,7 +370,7 @@ This ensures docs changes are on a separate branch, not directly on the current 
 docsfy download <project_name> --branch <branch> --provider <provider> --model <model> --output <output_dir> --flatten
 ```
 
-`<project_name>` is the same value extracted in Phase 3.
+`<project_name>` is the same value extracted from the `docsfy generate` output in Phase 2.
 
 The `--flatten` flag extracts docs directly into `<output_dir>/` instead of creating a nested subdirectory. It also handles model names with special characters (e.g., brackets) safely.
 
@@ -540,8 +553,8 @@ Display:
 
 | Command | Purpose |
 |---------|---------|
-| `docsfy generate <url> --watch` | Generate docs with live progress |
-| `docsfy generate <url> --watch --repo-type tests` | Generate docs for a test suite repo |
+| `docsfy generate <url>` | Start docs generation (returns immediately) |
+| `docsfy generate <url> --repo-type tests` | Generate docs for a test suite repo |
 | `docsfy status <name>` | Check generation status |
 | `docsfy download <name> -o <dir>` | Download docs to directory |
 | `docsfy list` | List all projects |
@@ -559,7 +572,7 @@ Display:
 | Hardcoding provider/model | Use `docsfy models --json` to get providers and models; free-form only on failure |
 | Skipping health check | Server must be reachable before generating |
 | Using local files instead of repo URL | docsfy works with Git repository URLs |
-| Forgetting `--watch` flag | Always use `--watch` for real-time progress |
+| Using `--watch` flag | Never use `--watch` — it blocks the chat. Poll with `docsfy status` instead |
 | Downloading before ready | Check status is `ready` before downloading |
 | Leaving nested download folder | Flatten after download — move files to output root |
 | Downloading before creating branch | Always create a docs branch before downloading |


### PR DESCRIPTION
## Problem

The `--watch` flag in `docsfy generate` opens a blocking WebSocket connection that prevents user interaction during documentation generation. The skill also referenced `Bash(run_in_background=true)` which does not exist in pi's bash tool.

Additionally, polling with `<project_name>` + `--branch/--provider/--model` flags can hit HTTP 409 errors when admins have same-named projects across multiple owners.

## Solution

### Replace `--watch` with non-blocking polling
- Run `docsfy generate` without `--watch` (returns immediately)
- Poll `docsfy status --json` every ~30 seconds
- Check `status` field for `ready`/`error`/`aborted`

### Use `<generation_id>` (UUID) for server operations
- Extract both `<project_name>` (for git branch name) and `<generation_id>` (for CLI commands) from `docsfy generate` output
- Use `<generation_id>` for `docsfy status`, `docsfy download`, and `docsfy abort` — avoids 409 ambiguity
- `<project_name>` is now only used for the git branch name (`docs/docsfy-<project_name>`)

## Changes

- **Phase 2**: Rewritten to use polling instead of `--watch`; extracts both `project_name` and `generation_id`
- **Phase 3**: Updated `<project_name>` reference to point to Phase 2 output
- **Phase 4**: `docsfy download` now uses `<generation_id>` instead of `<project_name>` + flags
- **Quick Reference**: Removed `--watch`; updated `status`/`download`/`abort` to use `<generation_id>`
- **Common Mistakes**: Flipped from "Forgetting `--watch`" to "Using `--watch`"

Note: The `--watch` CLI flag still exists in the codebase — this change only affects agent behavior via the skill instructions.