### PR TITLE
fix: resolve __clear__ sentinel leaking into UI, add models refresh, fix >100% progress

### DIFF
--- a/frontend/src/components/admin/SettingsPanel.tsx
+++ b/frontend/src/components/admin/SettingsPanel.tsx
@@ -178,12 +178,12 @@ export default function SettingsPanel({ availableModels, onSettingsSaved }: Sett
 
           <div className="flex flex-col gap-1.5">
             <Label htmlFor="default-provider">Default AI Provider</Label>
-            <Select value={provider || SELECT_CLEAR} onValueChange={handleProviderChange} disabled={saving}>
+            <Select value={provider || null} onValueChange={handleProviderChange} disabled={saving}>
               <SelectTrigger id="default-provider" className="w-full">
                 <SelectValue placeholder="No default" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="__clear__">No default</SelectItem>
+                <SelectItem value={SELECT_CLEAR}>No default</SelectItem>
                 {VALID_PROVIDERS.map((p) => (
                   <SelectItem key={p} value={p}>{p}</SelectItem>
                 ))}
@@ -215,12 +215,12 @@ export default function SettingsPanel({ availableModels, onSettingsSaved }: Sett
 
           <div className="flex flex-col gap-1.5">
             <Label htmlFor="vision-provider">Vision AI Provider</Label>
-            <Select value={visionProvider || SELECT_CLEAR} onValueChange={handleVisionProviderChange} disabled={saving}>
+            <Select value={visionProvider || null} onValueChange={handleVisionProviderChange} disabled={saving}>
               <SelectTrigger id="vision-provider" className="w-full">
                 <SelectValue placeholder="Same as generation provider" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="__clear__">Same as generation provider</SelectItem>
+                <SelectItem value={SELECT_CLEAR}>Same as generation provider</SelectItem>
                 {VALID_PROVIDERS.map((p) => (
                   <SelectItem key={p} value={p}>{p}</SelectItem>
                 ))}

--- a/frontend/src/components/shared/GenerateForm.tsx
+++ b/frontend/src/components/shared/GenerateForm.tsx
@@ -178,6 +178,13 @@ export default function GenerateForm({
     } else {
       setModel('')
     }
+    // When no vision provider is set, vision falls back to generation provider.
+    // Clear visionModel if it's invalid for the new generation provider.
+    if (!visionProvider && visionModel && models) {
+      if (!models.some(m => m.id === visionModel)) {
+        setVisionModel('')
+      }
+    }
   }
 
   function handleForceChange(checked: boolean) {

--- a/frontend/src/components/shared/GenerateForm.tsx
+++ b/frontend/src/components/shared/GenerateForm.tsx
@@ -101,8 +101,13 @@ export default function GenerateForm({
         setVisionModel('')
       }
     } else if (curVisionModel) {
-      // No vision provider selected — clear any stale vision model
-      setVisionModel('')
+      // No vision provider — validate against generation provider (backend fallback)
+      if (curProvider) {
+        const models = availableModels[curProvider]
+        if (models && !models.some(m => m.id === curVisionModel)) {
+          setVisionModel('')
+        }
+      }
     }
   }, [availableModels])
 

--- a/frontend/src/components/shared/GenerateForm.tsx
+++ b/frontend/src/components/shared/GenerateForm.tsx
@@ -72,6 +72,22 @@ export default function GenerateForm({
     if (savedRepoType && (VALID_REPO_TYPES as readonly string[]).includes(savedRepoType)) setRepoType(savedRepoType)
   }, [])
 
+  // Revalidate model selections when availableModels changes (e.g. after refresh)
+  useEffect(() => {
+    if (provider) {
+      const models = availableModels[provider]
+      if (models && model && !models.some(m => m.id === model)) {
+        setModel('')
+      }
+    }
+    if (visionProvider) {
+      const models = availableModels[visionProvider]
+      if (models && visionModel && !models.some(m => m.id === visionModel)) {
+        setVisionModel('')
+      }
+    }
+  }, [availableModels, provider, model, visionProvider, visionModel])
+
   // Sync server defaults into form when they arrive from /api/models
   useEffect(() => {
     if (defaultProvider && !provider) {

--- a/frontend/src/components/shared/GenerateForm.tsx
+++ b/frontend/src/components/shared/GenerateForm.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Loader2 } from 'lucide-react'
+import { Loader2, RefreshCw } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -14,6 +14,7 @@ import {
 import Combobox from '@/components/shared/Combobox'
 import { generateDocs } from '@/lib/api'
 import { SK_REPO, SK_BRANCH, SK_FORCE, SK_REPO_TYPE, TOAST_DEFAULT_MS, TOAST_ERROR_MS, VALID_PROVIDERS, VALID_REPO_TYPES, SELECT_CLEAR } from '@/lib/constants'
+import { cn } from '@/lib/utils'
 import type { AvailableModels } from '@/types'
 import { ApiError } from '@/types'
 interface GenerateFormProps {
@@ -24,6 +25,7 @@ interface GenerateFormProps {
   defaultVisionProvider?: string
   defaultVisionModel?: string
   onGenerated?: (name: string, branch: string, provider: string, model: string) => void
+  onRefreshModels?: () => Promise<void>
 }
 
 function extractRepoName(url: string): string {
@@ -43,6 +45,7 @@ export default function GenerateForm({
   defaultVisionProvider,
   defaultVisionModel,
   onGenerated,
+  onRefreshModels,
 }: GenerateFormProps) {
   const [repoUrl, setRepoUrl] = useState('')
   const [branch, setBranch] = useState('main')
@@ -53,6 +56,7 @@ export default function GenerateForm({
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [visionProvider, setVisionProvider] = useState('')
   const [visionModel, setVisionModel] = useState('')
+  const [isRefreshing, setIsRefreshing] = useState(false)
 
   // Restore form state from sessionStorage on mount
   useEffect(() => {
@@ -288,7 +292,20 @@ export default function GenerateForm({
 
         {/* Provider */}
         <div className="flex flex-col gap-1.5">
-          <Label htmlFor="provider-select" title="AI service provider to use for generation">Provider</Label>
+          <div className="flex items-center justify-between">
+            <Label htmlFor="provider-select" title="AI service provider to use for generation">Provider</Label>
+            {onRefreshModels && (
+              <button
+                type="button"
+                onClick={async () => { setIsRefreshing(true); try { await onRefreshModels(); } finally { setIsRefreshing(false); } }}
+                className="text-text-secondary hover:text-text-primary transition-colors"
+                title="Refresh available models"
+                disabled={isRefreshing || isSubmitting}
+              >
+                <RefreshCw className={cn('size-3.5', isRefreshing && 'animate-spin')} />
+              </button>
+            )}
+          </div>
           <Select disabled={isSubmitting} value={provider} onValueChange={(v) => { if (v) handleProviderChange(v) }}>
             <SelectTrigger id="provider-select" data-testid="provider-select" className="w-full">
               <SelectValue />
@@ -319,12 +336,12 @@ export default function GenerateForm({
         {/* Vision Provider */}
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="vision-provider-select" title="AI provider for image description (uses generation provider if not set)">Vision Provider</Label>
-          <Select disabled={isSubmitting} value={visionProvider || SELECT_CLEAR} onValueChange={handleVisionProviderChange}>
+          <Select disabled={isSubmitting} value={visionProvider || null} onValueChange={handleVisionProviderChange}>
             <SelectTrigger id="vision-provider-select" data-testid="vision-provider-select" className="w-full">
               <SelectValue placeholder="Same as generation provider" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="__clear__">Same as generation provider</SelectItem>
+              <SelectItem value={SELECT_CLEAR}>Same as generation provider</SelectItem>
               {VALID_PROVIDERS.map((p) => (
                 <SelectItem key={p} value={p}>
                   {p}

--- a/frontend/src/components/shared/GenerateForm.tsx
+++ b/frontend/src/components/shared/GenerateForm.tsx
@@ -100,6 +100,9 @@ export default function GenerateForm({
       if (models && curVisionModel && !models.some(m => m.id === curVisionModel)) {
         setVisionModel('')
       }
+    } else if (curVisionModel) {
+      // No vision provider selected — clear any stale vision model
+      setVisionModel('')
     }
   }, [availableModels])
 

--- a/frontend/src/components/shared/GenerateForm.tsx
+++ b/frontend/src/components/shared/GenerateForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { Loader2, RefreshCw } from 'lucide-react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -72,21 +72,36 @@ export default function GenerateForm({
     if (savedRepoType && (VALID_REPO_TYPES as readonly string[]).includes(savedRepoType)) setRepoType(savedRepoType)
   }, [])
 
-  // Revalidate model selections when availableModels changes (e.g. after refresh)
+  // Revalidate model selections when availableModels catalog changes (e.g. after refresh).
+  // Only depends on availableModels — reads provider/model via refs to avoid
+  // firing on every Combobox keystroke (free-text input).
+  const providerRef = useRef(provider)
+  const modelRef = useRef(model)
+  const visionProviderRef = useRef(visionProvider)
+  const visionModelRef = useRef(visionModel)
+  providerRef.current = provider
+  modelRef.current = model
+  visionProviderRef.current = visionProvider
+  visionModelRef.current = visionModel
+
   useEffect(() => {
-    if (provider) {
-      const models = availableModels[provider]
-      if (models && model && !models.some(m => m.id === model)) {
+    const curProvider = providerRef.current
+    const curModel = modelRef.current
+    if (curProvider) {
+      const models = availableModels[curProvider]
+      if (models && curModel && !models.some(m => m.id === curModel)) {
         setModel('')
       }
     }
-    if (visionProvider) {
-      const models = availableModels[visionProvider]
-      if (models && visionModel && !models.some(m => m.id === visionModel)) {
+    const curVisionProvider = visionProviderRef.current
+    const curVisionModel = visionModelRef.current
+    if (curVisionProvider) {
+      const models = availableModels[curVisionProvider]
+      if (models && curVisionModel && !models.some(m => m.id === curVisionModel)) {
         setVisionModel('')
       }
     }
-  }, [availableModels, provider, model, visionProvider, visionModel])
+  }, [availableModels])
 
   // Sync server defaults into form when they arrive from /api/models
   useEffect(() => {

--- a/frontend/src/components/shared/VariantDetail.tsx
+++ b/frontend/src/components/shared/VariantDetail.tsx
@@ -411,7 +411,7 @@ function RegenerateSection({
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div className="flex flex-col gap-1.5">
             <Label>Vision Provider</Label>
-            <Select value={visionProvider || SELECT_CLEAR} onValueChange={handleVisionProviderChange}>
+            <Select value={visionProvider || null} onValueChange={handleVisionProviderChange}>
               <SelectTrigger className="w-full">
                 <SelectValue placeholder="Same as generation provider" />
               </SelectTrigger>
@@ -581,8 +581,9 @@ function GeneratingView({
   const [isAborting, setIsAborting] = useState(false)
   const elapsed = useElapsedTime(project.generation_started_at)
 
-  const totalPages = getTotalPages(project.plan_json)
-  const progressPercent = totalPages > 0 ? Math.round((project.page_count / totalPages) * 100) : 0
+  const planPages = getTotalPages(project.plan_json)
+  const totalPages = Math.max(planPages, project.page_count)
+  const progressPercent = totalPages > 0 ? Math.min(100, Math.round((project.page_count / totalPages) * 100)) : 0
 
   async function handleAbort() {
     const confirmed = await modalConfirm({

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,6 @@
 import { toast } from 'sonner'
 import { ApiError } from '@/types'
-import type { AuthResponse, ProjectsResponse, AvailableModels, AdminSettingsResponse, AdminSettings, User, CreateUserResponse, RotateKeyResponse, AccessEntry, ModelsResponse } from '@/types'
+import type { AuthResponse, ProjectsResponse, AdminSettingsResponse, AdminSettings, User, CreateUserResponse, RotateKeyResponse, AccessEntry, ModelsResponse } from '@/types'
 import { encodeBranch } from '@/lib/utils'
 import { REDIRECT_DELAY_MS } from './constants'
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,6 @@
 import { toast } from 'sonner'
 import { ApiError } from '@/types'
-import type { AuthResponse, ProjectsResponse, AvailableModels, AdminSettingsResponse, AdminSettings, User, CreateUserResponse, RotateKeyResponse, AccessEntry } from '@/types'
+import type { AuthResponse, ProjectsResponse, AvailableModels, AdminSettingsResponse, AdminSettings, User, CreateUserResponse, RotateKeyResponse, AccessEntry, ModelsResponse } from '@/types'
 import { encodeBranch } from '@/lib/utils'
 import { REDIRECT_DELAY_MS } from './constants'
 
@@ -92,17 +92,12 @@ export function rotateKey(body?: { new_key?: string }) {
 }
 
 // Models
-export interface ModelsResponse {
-  providers: string[]
-  default_provider: string
-  default_model: string
-  default_vision_provider: string
-  default_vision_model: string
-  available_models: AvailableModels
-}
-
 export function getModels() {
   return api.get<ModelsResponse>('/api/models')
+}
+
+export function refreshModels() {
+  return api.post<ModelsResponse>('/api/models/refresh')
 }
 
 // Projects

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -25,7 +25,7 @@ import { useModal } from '@/components/shared/ModalProvider'
 import UsersPanel from '@/components/admin/UsersPanel'
 import AccessPanel from '@/components/admin/AccessPanel'
 import SettingsPanel from '@/components/admin/SettingsPanel'
-import { getModels, getMe, logout, rotateKey, getProjects, deleteAllVariants } from '@/lib/api'
+import { getModels, refreshModels, getMe, logout, rotateKey, getProjects, deleteAllVariants } from '@/lib/api'
 
 import { wsManager } from '@/lib/websocket'
 import { TOAST_DEFAULT_MS, TOAST_ERROR_MS, WS_POLLING_FALLBACK_MS, SELECTED_VIEW_KEY, SIDEBAR_COLLAPSED_KEY, GENERATION_STAGES } from '@/lib/constants'
@@ -35,7 +35,7 @@ import type {
   LogEntry,
   DocPlan,
 } from '@/types'
-import type { AvailableModels } from '@/types'
+import type { AvailableModels, ModelsResponse } from '@/types'
 import { ApiError } from '@/types'
 
 type SelectedView =
@@ -69,18 +69,32 @@ export default function DashboardPage() {
   const [defaultVisionModel, setDefaultVisionModel] = useState('')
   const [searchQuery, setSearchQuery] = useState('')
 
+  function applyModelsData(data: ModelsResponse) {
+    setAvailableModels(data.available_models ?? {})
+    setDefaultProvider(data.default_provider ?? '')
+    setDefaultModel(data.default_model ?? '')
+    setDefaultVisionProvider(data.default_vision_provider ?? '')
+    setDefaultVisionModel(data.default_vision_model ?? '')
+  }
+
   const loadModels = useCallback(async () => {
     try {
-      const data = await getModels()
-      setAvailableModels(data.available_models ?? {})
-      setDefaultProvider(data.default_provider ?? '')
-      setDefaultModel(data.default_model ?? '')
-      setDefaultVisionProvider(data.default_vision_provider ?? '')
-      setDefaultVisionModel(data.default_vision_model ?? '')
+      applyModelsData(await getModels())
     } catch {
       /* best-effort — models dropdown will be empty */
     }
   }, [])
+
+  const handleRefreshModels = useCallback(async () => {
+    try {
+      applyModelsData(await refreshModels())
+      toast.success('Models refreshed', { duration: TOAST_DEFAULT_MS })
+    } catch (err) {
+      const detail = err instanceof ApiError ? err.detail : 'Failed to refresh models'
+      toast.error(detail, { duration: TOAST_ERROR_MS })
+    }
+  }, [])
+
   const [selectedView, setSelectedView] = useState<SelectedView>(() => {
     try {
       const stored = localStorage.getItem(SELECTED_VIEW_KEY)
@@ -154,11 +168,7 @@ export default function DashboardPage() {
     loadProjects()
     getModels().then((data) => {
       if (cancelled) return
-      setAvailableModels(data.available_models ?? {})
-      setDefaultProvider(data.default_provider ?? '')
-      setDefaultModel(data.default_model ?? '')
-      setDefaultVisionProvider(data.default_vision_provider ?? '')
-      setDefaultVisionModel(data.default_vision_model ?? '')
+      applyModelsData(data)
     }).catch(() => { /* best-effort */ })
     return () => { cancelled = true }
   }, [authChecked])
@@ -620,6 +630,7 @@ export default function DashboardPage() {
           setSelectedView({ type: 'variant', name, branch, provider, model, owner })
         }}
         onSettingsSaved={loadModels}
+        onRefreshModels={handleRefreshModels}
       />
     </Layout>
   )
@@ -825,6 +836,7 @@ function MainPanel({
   onGenerated,
   onVariantRegenerate,
   onSettingsSaved,
+  onRefreshModels,
 }: {
   selectedView: SelectedView
   username: string
@@ -841,6 +853,7 @@ function MainPanel({
   onGenerated: (name: string, branch: string, provider: string, model: string) => void
   onVariantRegenerate: (name: string, branch: string, provider: string, model: string, owner: string) => void
   onSettingsSaved: () => void
+  onRefreshModels?: () => Promise<void>
 }) {
   if (selectedView.type === 'empty') {
     return (
@@ -864,6 +877,7 @@ function MainPanel({
         defaultVisionProvider={defaultVisionProvider}
         defaultVisionModel={defaultVisionModel}
         onGenerated={onGenerated}
+        onRefreshModels={isAdmin ? onRefreshModels : undefined}
       />
     )
   }

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -98,6 +98,15 @@ export interface RotateKeyResponse {
   new_api_key: string
 }
 
+export interface ModelsResponse {
+  providers: string[]
+  default_provider: string
+  default_model: string
+  default_vision_provider: string
+  default_vision_model: string
+  available_models: AvailableModels
+}
+
 /**
  * WebSocket messages use `provider`/`model` field names, while the Project
  * type uses `ai_provider`/`ai_model` to match the backend DB schema. This is

--- a/src/docsfy/ai_client.py
+++ b/src/docsfy/ai_client.py
@@ -1,17 +1,28 @@
 """AI client adapter — re-exports from pi-sidecar-client."""
 
+from typing import Any
+
 from pi_sidecar_client import (
     AIResult,
     call_ai_once,
     check_sidecar_available,
+    get_sidecar_client,
     list_models,
     run_parallel_with_limit,
 )
+
+
+async def refresh_models() -> list[dict[str, Any]]:
+    """Trigger model re-discovery on the sidecar and return updated list."""
+    client = get_sidecar_client()
+    return await client.refresh_models()
+
 
 __all__ = [
     "AIResult",
     "call_ai_once",
     "check_sidecar_available",
     "list_models",
+    "refresh_models",
     "run_parallel_with_limit",
 ]

--- a/src/docsfy/api/projects.py
+++ b/src/docsfy/api/projects.py
@@ -1500,7 +1500,7 @@ async def refresh_models_endpoint(request: Request) -> dict[str, Any]:
     try:
         await refresh_models()
     except Exception as exc:
-        logger.warning("Failed to refresh models from sidecar: %s", exc)
+        logger.warning("Failed to refresh models from sidecar: %s", exc, exc_info=True)
         raise HTTPException(
             status_code=502, detail="Failed to refresh models from sidecar"
         )

--- a/src/docsfy/api/projects.py
+++ b/src/docsfy/api/projects.py
@@ -18,7 +18,7 @@ from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import StreamingResponse
 from simple_logger.logger import get_logger
 
-from docsfy.ai_client import check_sidecar_available, list_models
+from docsfy.ai_client import check_sidecar_available, list_models, refresh_models
 from docsfy.cost_tracker import (
     CostAccumulator,
     set_cost_accumulator,
@@ -1485,6 +1485,28 @@ async def get_models_endpoint() -> dict[str, Any]:
         "default_vision_model": default_vision_model,
         "available_models": available_models,
     }
+
+
+@router.post("/models/refresh")
+async def refresh_models_endpoint(request: Request) -> dict[str, Any]:
+    """Trigger model re-discovery on the sidecar and return fresh models.
+
+    Requires admin authentication.
+    """
+    if not request.state.is_admin:
+        raise HTTPException(status_code=403, detail="Admin access required")
+
+    logger.info("Admin %s triggered model refresh", request.state.username)
+    try:
+        await refresh_models()
+    except Exception as exc:
+        logger.warning("Failed to refresh models from sidecar: %s", exc)
+        raise HTTPException(
+            status_code=502, detail="Failed to refresh models from sidecar"
+        )
+
+    # Return fresh model list (same as GET /models)
+    return await get_models_endpoint()
 
 
 @router.get("/cost")

--- a/src/docsfy/cli/client.py
+++ b/src/docsfy/cli/client.py
@@ -47,6 +47,11 @@ class DocsfyClient:
         response = self.get("/api/models")
         return response.json()
 
+    def refresh_models(self) -> dict[str, Any]:
+        """Trigger model refresh and return updated models."""
+        response = self.post("/api/models/refresh")
+        return response.json()
+
     def download(self, path: str, output_path: Path) -> None:
         """Stream-download a file to the given path using atomic write."""
         import tempfile

--- a/src/docsfy/cli/projects.py
+++ b/src/docsfy/cli/projects.py
@@ -463,6 +463,10 @@ def models(
         Optional[str],
         typer.Option("--provider", "-P", help="Filter by provider"),
     ] = None,
+    refresh: Annotated[
+        bool,
+        typer.Option("--refresh", "-r", help="Refresh models from AI providers"),
+    ] = False,
     json_output: Annotated[
         bool,
         typer.Option("--json", "-j", help="Output as JSON"),
@@ -473,7 +477,12 @@ def models(
 
     client = get_client()
     try:
-        data = client.get_models()
+        if refresh:
+            data = client.refresh_models()
+            if not json_output:
+                typer.echo("Models refreshed from AI providers.\n")
+        else:
+            data = client.get_models()
     finally:
         client.close()
 

--- a/test-plans/e2e-14-models-command.md
+++ b/test-plans/e2e-14-models-command.md
@@ -179,6 +179,77 @@ print(f'Providers with models: {providers_with_models}')
 
 ---
 
-### 28.8 Cleanup
+### 28.8 Models refresh triggers re-discovery
+
+**Commands:**
+
+```shell
+docsfy models --refresh
+```
+
+**Expected result:**
+- The output begins with `Models refreshed from AI providers.`
+- Followed by the normal provider/model listing
+- Models are re-discovered from the sidecar (not served from cache)
+
+---
+
+### 28.9 Models refresh with JSON output
+
+**Commands:**
+
+```shell
+docsfy models --refresh --json
+```
+
+**Expected result:**
+- The output is valid JSON (no "Models refreshed" text since JSON mode)
+- Contains `providers`, `default_provider`, `default_model`, and `available_models`
+- Models are freshly discovered (same structure as 28.4)
+
+---
+
+### 28.10 API refresh endpoint requires admin auth
+
+**Commands:**
+
+```shell
+# Without auth
+curl -s -o /dev/null -w "%{http_code}" -X POST "$DOCSFY_SERVER/api/models/refresh"
+```
+
+**Expected result:**
+- HTTP status code is `401` (unauthorized)
+
+**With non-admin auth:**
+
+```shell
+curl -s -o /dev/null -w "%{http_code}" -X POST "$DOCSFY_SERVER/api/models/refresh" \
+  -H "Authorization: Bearer $TEST_USER_PASSWORD"
+```
+
+**Expected result:**
+- HTTP status code is `403` (forbidden, admin required)
+
+**With admin auth:**
+
+```shell
+curl -s -X POST "$DOCSFY_SERVER/api/models/refresh" \
+  -H "Authorization: Bearer $ADMIN_KEY" | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+assert 'providers' in data
+assert 'available_models' in data
+print('Refresh endpoint returned valid models response')
+"
+```
+
+**Expected result:**
+- HTTP status code is `200`
+- Response has same structure as `GET /api/models`
+
+---
+
+### 28.11 Cleanup
 
 **No cleanup needed.** Test 28.7 only queries available models and does not create any variant.

--- a/test-plans/e2e-16-admin-settings.md
+++ b/test-plans/e2e-16-admin-settings.md
@@ -160,7 +160,52 @@ curl -s "$SERVER/api/models" | jq '{default_provider, default_model}'
 
 ---
 
-### 33.12 Generate fails without provider when no default configured
+### 33.12 Settings page shows placeholder when no default is selected
+
+Clear defaults via API:
+```bash
+curl -s -X PUT -H "Authorization: Bearer $ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  "$SERVER/api/admin/settings" \
+  -d '{"settings": {"default_ai_provider": "", "default_ai_model": "", "vision_provider": "", "vision_model": ""}}'
+```
+
+Navigate to the Settings page.
+
+**Expected result:**
+- Default AI Provider select shows placeholder text "No default" (not `__clear__` or empty)
+- Vision AI Provider select shows placeholder text "Same as generation provider" (not `__clear__` or empty)
+
+Navigate to the Generate form.
+
+**Expected result:**
+- Vision Provider select shows placeholder text "Same as generation provider" (not `__clear__` or empty)
+
+---
+
+### 33.13 Refresh models button visible for admin
+
+Navigate to the Generate form as admin.
+
+**Expected result:**
+- A small refresh icon (⟳) appears next to the "Provider" label
+- Clicking it triggers model re-discovery from AI providers
+- A success toast "Models refreshed" appears
+- The provider/model dropdowns are updated with fresh data
+
+---
+
+### 33.14 Refresh models button not visible for non-admin
+
+Log in as `$TEST_USER` via the UI. Navigate to the Generate form.
+
+**Expected result:**
+- No refresh icon appears next to the "Provider" label
+- Non-admin users cannot trigger model refresh
+
+---
+
+### 33.15 Generate fails without provider when no default configured
 
 Clear the default provider:
 ```bash
@@ -182,7 +227,7 @@ curl -s -X POST -H "Authorization: Bearer $ADMIN_KEY" \
 
 ---
 
-### 33.13 Cleanup
+### 33.16 Cleanup
 
 Restore defaults:
 ```bash

--- a/test-plans/e2e-ui-test-plan.md
+++ b/test-plans/e2e-ui-test-plan.md
@@ -204,12 +204,12 @@ Each linked sub-file contains only the detailed test bodies for its assigned sec
 | 25 | Sidebar Collapse Toggle Position | 25.1-25.4 |
 | 26 | Dialog Theme Consistency | 26.1-26.2 |
 | 27 | Post-Generation Pipeline | 27.1-27.11 |
-| 28 | Models Command | 28.1-28.8 |
+| 28 | Models Command | 28.1-28.11 |
 | 29 | Cost Tracking | 29.1-29.6 |
 | 30 | Repo Type API Validation | 30.1-30.3 |
 | 31 | Repo Type UI Elements | 31.1-31.4 |
 | 32 | Repo Type CLI | 32.1-32.3 |
-| 33 | Admin Settings Page | 33.1-33.13 |
+| 33 | Admin Settings Page | 33.1-33.16 |
 | 34 | Image Support in Documentation | 34.1-34.9 |
 | 21 | Cleanup and Teardown | 21.1-21.5 |
 

--- a/tests/test_ai_client.py
+++ b/tests/test_ai_client.py
@@ -7,12 +7,14 @@ def test_reexports_available() -> None:
         call_ai_once,
         check_sidecar_available,
         list_models,
+        refresh_models,
         run_parallel_with_limit,
     )
 
     assert callable(call_ai_once)
     assert callable(check_sidecar_available)
     assert callable(list_models)
+    assert callable(refresh_models)
     assert callable(run_parallel_with_limit)
     # AIResult is a dataclass
     assert "success" in AIResult.__dataclass_fields__

--- a/tests/test_api_projects.py
+++ b/tests/test_api_projects.py
@@ -158,6 +158,66 @@ async def test_get_models_no_auth_required() -> None:
             get_settings.cache_clear()
 
 
+async def test_refresh_models_requires_admin() -> None:
+    """POST /api/models/refresh requires admin authentication."""
+    import docsfy.storage as storage
+    from docsfy.config import get_settings
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        orig_db = storage.DB_PATH
+        orig_data = storage.DATA_DIR
+        orig_projects = storage.PROJECTS_DIR
+
+        storage.DB_PATH = tmp_path / "test.db"
+        storage.DATA_DIR = tmp_path
+        storage.PROJECTS_DIR = tmp_path / "projects"
+
+        get_settings.cache_clear()
+
+        from docsfy.main import app
+
+        try:
+            with patch.dict(os.environ, {"ADMIN_KEY": TEST_ADMIN_KEY}):
+                get_settings.cache_clear()
+                await storage.init_db()
+                transport = ASGITransport(app=app)
+                # No auth header
+                async with AsyncClient(
+                    transport=transport, base_url="http://test"
+                ) as ac:
+                    response = await ac.post("/api/models/refresh")
+                    assert response.status_code == 401
+        finally:
+            storage.DB_PATH = orig_db
+            storage.DATA_DIR = orig_data
+            storage.PROJECTS_DIR = orig_projects
+            get_settings.cache_clear()
+
+
+async def test_refresh_models_as_admin(client: AsyncClient) -> None:
+    """POST /api/models/refresh returns valid models structure for admin."""
+    with patch("docsfy.api.projects.refresh_models") as mock_refresh:
+        mock_refresh.return_value = []
+        response = await client.post("/api/models/refresh")
+    assert response.status_code == 200
+    data = response.json()
+    assert "providers" in data
+    assert "available_models" in data
+    assert "default_provider" in data
+
+
+async def test_refresh_models_sidecar_failure(client: AsyncClient) -> None:
+    """POST /api/models/refresh returns 502 when sidecar fails."""
+    with patch("docsfy.api.projects.refresh_models") as mock_refresh:
+        mock_refresh.side_effect = ConnectionError("sidecar down")
+        response = await client.post("/api/models/refresh")
+    assert response.status_code == 502
+    assert "Failed to refresh models from sidecar" in response.json()["detail"]
+
+
 async def test_get_cost_returns_total(client: AsyncClient) -> None:
     """GET /api/cost returns total_cost_usd."""
     response = await client.get("/api/cost")

--- a/tests/test_cli_projects.py
+++ b/tests/test_cli_projects.py
@@ -409,6 +409,38 @@ class TestModels:
         data = json.loads(result.output)
         assert data == api_data
 
+    def test_models_refresh_calls_refresh_method(self, mock_client: MagicMock) -> None:
+        mock_client.refresh_models.return_value = {
+            "providers": ["claude", "gemini", "cursor"],
+            "default_provider": "cursor",
+            "default_model": "gpt-5.4-xhigh-fast",
+            "available_models": {
+                "cursor": [{"id": "gpt-5.4-xhigh-fast", "name": "GPT 5.4"}],
+            },
+        }
+        result = runner.invoke(app, ["models", "--refresh"])
+        assert result.exit_code == 0
+        mock_client.refresh_models.assert_called_once()
+        mock_client.get_models.assert_not_called()
+        assert "Models refreshed from AI providers" in result.output
+
+    def test_models_refresh_json_no_confirmation(self, mock_client: MagicMock) -> None:
+        api_data = {
+            "providers": ["claude", "gemini", "cursor"],
+            "default_provider": "cursor",
+            "default_model": "gpt-5.4-xhigh-fast",
+            "available_models": {
+                "cursor": [{"id": "gpt-5.4-xhigh-fast", "name": "GPT 5.4"}],
+            },
+        }
+        mock_client.refresh_models.return_value = api_data
+        result = runner.invoke(app, ["models", "--refresh", "--json"])
+        assert result.exit_code == 0
+        mock_client.refresh_models.assert_called_once()
+        assert "Models refreshed" not in result.output
+        data = json.loads(result.output)
+        assert data == api_data
+
     def test_models_json_filtered_by_provider(self, mock_client: MagicMock) -> None:
         mock_client.get_models.return_value = {
             "providers": ["claude", "gemini", "cursor"],


### PR DESCRIPTION
Closes #110

## Changes

### Bug 1: `__clear__` sentinel leaking into Select dropdowns
- Replace `value={... || SELECT_CLEAR}` with `value={... || null}` so placeholder text shows instead of raw `__clear__` sentinel (GenerateForm, SettingsPanel, VariantDetail)
- Use `SELECT_CLEAR` constant in `SelectItem` values instead of hardcoded `"__clear__"` string

### Bug 2: No way to refresh models without server restart
- Add `refresh_models()` to `ai_client.py` wrapping sidecar `POST /models/refresh`
- Add `POST /api/models/refresh` admin-only API endpoint with logging and stack trace on failure
- Add refresh icon button (⟳) next to Provider label in GenerateForm (admin only)
- Add `docsfy models --refresh` CLI flag
- Add `refreshModels()` API client function
- Revalidate model selections after refresh — clear stale model choices when they no longer exist in the refreshed list

### Bug 3: Progress bar showing >100% during gap page generation
- Use `Math.max(planPages, page_count)` as denominator and cap at 100%

### Code quality
- Extract `applyModelsData()` helper in DashboardPage to DRY up model state updates
- Move `ModelsResponse` type from `api.ts` to `types/index.ts` for consistency

### Tests
- Add `refresh_models` to ai_client re-export test
- Add 3 API tests for refresh endpoint (no auth → 401, admin → 200, sidecar failure → 502)
- Add 2 CLI tests for `--refresh` flag (text and JSON modes)
- **379 tests pass**

### E2E test plans
- `e2e-14`: Add tests 28.8–28.10 (CLI refresh, JSON refresh, API auth)
- `e2e-16`: Add tests 33.12–33.14 (placeholder text, refresh button visibility)
- Update index test ranges